### PR TITLE
Add smoke tests and fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+- add smoke tests for repo layout and Redis connectivity
 - enable runtime counting via adapter to vision.counting
 - improve MJPEG streaming: reuse last frame when stalled, throttle writes,
   and handle broken pipes cleanly

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,5 @@ filterwarnings =
     ignore:Specified provider 'CUDAExecutionProvider':UserWarning
 markers =
     slow: marks tests as slow
+    integration: marks tests requiring external services
+    gpu: marks tests that exercise GPU paths

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,26 @@
+"""Basic smoke tests for repository health."""
+
+from pathlib import Path
+
+import pytest
+import redis
+
+
+def test_repo_layout_exists() -> None:
+    """Ensure fundamental project files are present."""
+    assert Path("README.md").is_file()
+    assert Path("tests").is_dir()
+
+
+@pytest.mark.integration
+def test_redis_connectivity(redis_url: str) -> None:
+    """Verify a Redis server is reachable."""
+    client = redis.Redis.from_url(redis_url)
+    assert client.ping()
+    client.close()
+
+
+@pytest.mark.gpu
+def test_gpu_dummy() -> None:
+    """Placeholder GPU test."""
+    assert True


### PR DESCRIPTION
## Summary
- add fixtures for temporary Redis and Postgres DSN
- introduce basic smoke tests for repo layout, Redis, and GPU placeholder
- register integration and gpu pytest markers

## Testing
- `pre-commit run --files tests/conftest.py tests/test_smoke.py tests/__init__.py CHANGELOG.md pytest.ini`
- `pytest tests/test_smoke.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af0d9dd3d8832ab97b54f27ed1278f