### PR TITLE
chore: add project Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: setup precommit lint format test unit integ cov
+
+setup:
+	python3 -m pip install --upgrade pip
+	python3 -m pip install -r requirements.txt
+
+precommit:
+	python3 -m pre_commit run --files $(git diff --name-only --cached)
+
+lint:
+	python3 -m ruff .
+
+format:
+	python3 -m isort .
+	python3 -m black . --extend-exclude "app/core/config.py"
+
+test:
+	python3 -m pytest
+
+unit:
+	python3 -m pytest tests/test_overlay_draw.py tests/test_image_utils.py
+
+integ:
+	python3 -m pytest tests/integration
+
+cov:
+	python3 -m pytest --cov=.


### PR DESCRIPTION
## Summary
- add root Makefile with setup, lint, format, test, and other targets

## Testing
- `make format`
- `make unit`


------
https://chatgpt.com/codex/tasks/task_e_68af0d9af410832a8fa3c6f3c7cf6415