### PR TITLE
Add PostgreSQL integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+- add integration test for PostgreSQL connectivity using the `postgres_dsn` fixture
 - enable runtime counting via adapter to vision.counting
 - improve MJPEG streaming: reuse last frame when stalled, throttle writes,
   and handle broken pipes cleanly

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,6 +72,7 @@ pipes cause the reader to restart FFmpeg with an exponential backoff capped at
 - Redis server (a running instance is required; fakeredis is not bundled)
 - `ffmpeg` command-line tools
 - Installed Python dependencies from `requirements.txt` (including `ultralytics`)
+- Optional PostgreSQL driver (`psycopg2` or `asyncpg`) and accessible database for integration tests
 - Optional GPU with CUDA for accelerated inference
 
 ## Module Documentation
@@ -100,7 +101,9 @@ message including prune counts.
    ```
    For HTTPS, pass `--ssl-certfile` and `--ssl-keyfile` or run behind a reverse proxy.
 4. Run the test suite to verify your environment:
-   ```bash
-   python3 -m pytest -q
-   ```
+    ```bash
+    python3 -m pytest -q
+    ```
+   The PostgreSQL integration test in `tests/test_postgres.py` requires a working
+   `postgres_dsn` fixture and either `psycopg2` or `asyncpg`; if unavailable, the test is skipped.
 5. See [CONTRIBUTING.md](../CONTRIBUTING.md) for development guidelines.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ ignore = ["E203", "E266", "E501"]
 addopts = "-ra -k 'not test_faces and not test_tracker_redis and not test_admin_user_management'"
 markers = [
     "slow: marks tests as slow",
+    "integration: marks tests that require external services",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1,0 +1,46 @@
+import asyncio
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_postgres_connection(request):
+    try:
+        dsn = request.getfixturevalue("postgres_dsn")
+    except pytest.FixtureLookupError:
+        pytest.skip("postgres_dsn fixture not provided")
+
+    try:
+        import psycopg2
+    except Exception:
+        psycopg2 = None
+    try:
+        import asyncpg
+    except Exception:
+        asyncpg = None
+
+    if psycopg2 is None and asyncpg is None:
+        pytest.skip("psycopg2 or asyncpg is required for this test")
+
+    if psycopg2 is not None:
+        try:
+            conn = psycopg2.connect(dsn, connect_timeout=1)
+        except Exception:
+            pytest.skip("psycopg2 could not connect")
+        with conn.cursor() as cur:
+            cur.execute("SELECT 1")
+            assert cur.fetchone()[0] == 1
+        conn.close()
+        return
+
+    async def _check_asyncpg():
+        try:
+            conn = await asyncpg.connect(dsn, timeout=1)
+        except Exception:
+            pytest.skip("asyncpg could not connect")
+        val = await conn.fetchval("SELECT 1")
+        assert val == 1
+        await conn.close()
+
+    asyncio.run(_check_asyncpg())


### PR DESCRIPTION
## Summary
- add integration test to exercise PostgreSQL connectivity via `postgres_dsn`
- document optional PostgreSQL requirement for integration tests
- register `integration` pytest marker

## Testing
- `pre-commit run --files tests/test_postgres.py CHANGELOG.md docs/architecture.md pyproject.toml`
- `pytest tests/test_postgres.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af119e4bf0832a89cf7cae3dae30c0