### PR TITLE
ci: run Node tests and add troubleshooting guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,23 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: requirements.txt
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Install npm dependencies
+        run: npm ci
+      - name: Run Jest tests
+        run: npm test -- --json --outputFile=jest-results.json
+      - name: Upload Jest results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jest-results
+          path: jest-results.json
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Lint
@@ -72,6 +89,23 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: requirements.txt
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Install npm dependencies
+        run: npm ci
+      - name: Run Jest tests
+        run: npm test -- --json --outputFile=jest-results.json
+      - name: Upload Jest results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jest-results
+          path: jest-results.json
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Integration tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ bash scripts/run_all_tests.sh
 ## Continuous Integration
 
 The GitHub Actions workflow at `.github/workflows/ci.yaml` executes the same test script on every push and pull request.
+If a workflow fails, consult [CI Troubleshooting](docs/ci-troubleshooting.md) for common issues and resolutions.
 
 ## Issues and Pull Requests
 

--- a/docs/ci-troubleshooting.md
+++ b/docs/ci-troubleshooting.md
@@ -1,0 +1,18 @@
+# CI Troubleshooting
+
+When GitHub Actions runs fail, the tips below cover the most common culprits and how to resolve them.
+
+## Network restrictions
+Self-hosted or corporate runners may block outbound network access. This prevents dependency downloads and external API calls.
+
+**Resolution:** Ensure required domains are whitelisted and that proxies allow the runner to reach PyPI, npm, and other services. Retry the job after network access is restored.
+
+## Missing `GITHUB_TOKEN`
+Some steps rely on the automatically provided `GITHUB_TOKEN` for authentication. If the token is missing or has insufficient permissions, the workflow may fail to check out code or publish artifacts.
+
+**Resolution:** Verify that the workflow is running in a GitHub context where `GITHUB_TOKEN` is available and has the necessary scopes. For forks, enable workflows or provide a personal access token with appropriate rights.
+
+## Artifact upload limits
+Large test logs or coverage reports can exceed GitHub's artifact size or retention limits.
+
+**Resolution:** Prune unnecessary files before uploading, or split artifacts into smaller pieces. Consider storing large artifacts in external storage if they regularly exceed the limits.


### PR DESCRIPTION
## Summary
- run npm tests in CI with Node 20 and cached modules
- upgrade pip before installing deps in CI
- add CI troubleshooting guide

## Testing
- `npm test -- --json --outputFile=jest-results.json`
- `pre-commit run --files .github/workflows/ci.yml docs/ci-troubleshooting.md CONTRIBUTING.md`
- `pytest -m "not integration and not gpu and not slow"` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68af14bd652c832a810ce2d0380f4b46