### PR TITLE
fix: use pyproject for pytest config

### DIFF
--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -9,7 +9,7 @@ function cleanup {
 trap cleanup EXIT
 
 ruff check key_gen.py
-pytest -c pytest.ini
+pytest
 
 uvicorn app:app --host 0.0.0.0 --port 5000 &
 UVICORN_PID=$!


### PR DESCRIPTION
## Summary
- use existing pyproject.toml for pytest configuration in CI helper script

## Testing
- `npm test`
- `scripts/run_all_tests.sh` *(fails: 86 failed, 62 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b03ba4428c832ab6938422b574af19