### PR TITLE
Clean up face-recognition leftovers

### DIFF
--- a/routers/blueprints.py
+++ b/routers/blueprints.py
@@ -32,7 +32,6 @@ from . import (
     rtsp,
     settings,
     troubleshooter,
-    visitor,
     vms,
 )
 from .admin import users as admin_users
@@ -48,7 +47,6 @@ MODULES = [
     alerts,
     auth,
     admin_users,
-    visitor,
     api_identities,
     api_summary,
     vms,
@@ -96,7 +94,6 @@ def init_all(
     ppe_reports.init_context(cfg, trackers, redis_client, templates_dir, redis_facade)
     alerts.init_context(cfg, trackers, redis_client, templates_dir, config_path, redis_facade)
     admin_users.init_context(cfg, redis_client, templates_dir, config_path, redis_facade)
-    visitor.init_context(cfg, redis_client, templates_dir, cams, redis_facade)
     api_identities.init_context(cfg, redis_client, redis_facade)
     diagnostics.init_context(cfg, trackers, cams, templates_dir, redis_facade)
     troubleshooter.init_context(cfg, trackers, cams, templates_dir, redis_facade)

--- a/routers/gatepass/__init__.py
+++ b/routers/gatepass/__init__.py
@@ -19,7 +19,6 @@ from config import config as cfg
 from modules import gatepass_service, visitor_db
 from modules.email_utils import send_email, sign_token
 from schemas.gatepass import GatepassRequiredFields
-from utils.face_db_utils import add_face_to_known_db, save_base64_to_image
 from utils.redis import trim_sorted_set_sync
 
 router = APIRouter()
@@ -32,7 +31,6 @@ GATEPASS_RETENTION_SECS = 7 * 24 * 60 * 60  # default to 7 days
 config_obj: dict = {}
 redis = None
 templates: Jinja2Templates | None = None
-face_db = None
 visitor = SimpleNamespace(
     _save_visitor_master=lambda *a, **k: None,
     invalidate_host_cache=lambda: None,
@@ -360,7 +358,6 @@ from .approval import (  # noqa: E402,F401
 )
 from .create import (  # noqa: E402,F401
     gatepass_active,
-    gatepass_auto_crop,
     gatepass_checkout,
     gatepass_create,
     gatepass_delete,
@@ -398,7 +395,6 @@ __all__ = [
     "gatepass_view",
     "gatepass_list",
     "gatepass_export",
-    "gatepass_auto_crop",
     "gatepass_active",
     "gatepass_create",
     "gatepass_verify_form",


### PR DESCRIPTION
## Summary
- drop visitor router registration
- remove face recognition hooks from gatepass routes

## Testing
- `python app.py` *(fails: Error 111 connecting to localhost:6379. Connection refused)*
- `pytest` *(fails: ImportError: cannot import name 'face_db' from 'modules')*

------
https://chatgpt.com/codex/tasks/task_e_68b03fb1ae50832a96c3d67ed6cad219