### PR TITLE
refactor: remove redundant logging import

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from fastapi import FastAPI
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -9,21 +11,15 @@ from loguru import logger
 from starlette.middleware.sessions import SessionMiddleware
 
 import logging_config  # noqa: F401
-from app.core.logging import setup_json_logger
+from app.web import api_perf
+from core.config import get_config
+from core.logging import setup_json_logger
 from modules.utils import SNAP_DIR
 from routers import whatsapp
-from app.web import api_perf
-from datetime import datetime
-
-from core.logging import setup_json_logger
-from core.config import get_config
-
 from server.config import _load_secret_key
 from server.startup import handle_unexpected_error
 from server.startup import init_app as _init_app
 from server.startup import lifespan
-from utils.redis import get_sync_client
-
 
 
 def init_app(


### PR DESCRIPTION
## Summary
- remove duplicate `setup_json_logger` import so app relies solely on `core.logging`

## Testing
- `pre-commit run --files app.py`
- `pytest tests/test_logging_config_thread_safe.py`
- `python - <<'PY'
from core.logging import setup_json_logger
setup_json_logger()
from loguru import logger
logger.info('json log test')
PY`
- `python - <<'PY'
import importlib.util
spec = importlib.util.spec_from_file_location('app_main', 'app.py')
app_module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(app_module)
from loguru import logger
logger.info('test message after app import')
PY` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0536deea8832aa597c08b11137ed2