### PR TITLE
Refactor camera manager frame cache and flags helper

### DIFF
--- a/modules/tracker/stream.py
+++ b/modules/tracker/stream.py
@@ -19,7 +19,7 @@ except ModuleNotFoundError:  # pragma: no cover - torch is optional in tests
 from app.core.perf import PERF
 from core.events import CAPTURE_ERROR, CAPTURE_READ_FAIL, CAPTURE_START, CAPTURE_STOP
 from modules.camera_factory import StreamUnavailable, open_capture
-from modules.camera_manager import LATEST_FRAMES
+from modules.camera_manager import update_latest_frame
 from modules.profiler import register_thread
 from utils.logx import error as log_error
 from utils.logx import event as log_event
@@ -198,10 +198,7 @@ class CaptureWorker:
                         except queue.Empty:
                             pass
                     t.raw_frame = frame
-                    LATEST_FRAMES[t.cam_id] = {
-                        "ts": time.monotonic(),
-                        "bgr": frame.copy(),
-                    }
+                    update_latest_frame(t.cam_id, frame.copy())
                     if (
                         use_gpu
                         and torch is not None

--- a/tests/test_camera_manager_helpers.py
+++ b/tests/test_camera_manager_helpers.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+
+from modules.camera_manager import CameraManager
+
+
+@pytest.mark.asyncio
+async def test_frame_cache_is_instance_scoped():
+    cams = [{"id": 1, "url": "", "tasks": []}]
+    trackers1 = {}
+    trackers2 = {}
+    start = lambda cam, cfg, trackers, r: None
+    stop = lambda cid, tr: None
+
+    mgr1 = CameraManager({}, trackers1, {}, None, lambda: cams, start, stop)
+    mgr2 = CameraManager({}, trackers2, {}, None, lambda: cams, start, stop)
+
+    frame = np.zeros((1, 1, 3), dtype=np.uint8)
+    await mgr1._update_latest(1, frame)
+
+    assert 1 in mgr1._latest_frames
+    assert 1 not in mgr2._latest_frames
+
+
+def test_build_flags():
+    cams = []
+    trackers = {}
+    start = lambda cam, cfg, trackers, r: None
+    stop = lambda cid, tr: None
+    mgr = CameraManager({}, trackers, {}, None, lambda: cams, start, stop)
+
+    cam = {
+        "enabled": False,
+        "ppe": True,
+        "visitor_mgmt": True,
+        "face_recognition": True,
+        "tasks": ["in_count"],
+    }
+    flags = mgr._build_flags(cam)
+    assert flags == {
+        "enabled": False,
+        "ppe": True,
+        "vms": True,
+        "face": True,
+        "counting": True,
+    }


### PR DESCRIPTION
## Summary
- manage latest frames per CameraManager instance with async lock and helper to update from capture threads
- consolidate start/restart flag building into a private helper
- add tests for flag helper and frame cache isolation

## Testing
- `pytest tests/test_camera_manager_helpers.py tests/test_camera_manager_online_status.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b053837358832a89f315513422ae86