### PR TITLE
Refactor BaseCameraStream to enforce abstract interface

### DIFF
--- a/modules/base_camera.py
+++ b/modules/base_camera.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import threading
 import time
+from abc import ABC, abstractmethod
 from collections import deque
 from typing import Optional, Tuple
 
@@ -11,7 +12,7 @@ import numpy as np
 
 
 # BaseCameraStream class encapsulates basecamerastream behavior
-class BaseCameraStream:
+class BaseCameraStream(ABC):
     """Generic threaded capture with a small rolling buffer.
 
     Buffer size ``N`` adds roughly ``N / fps`` seconds of latency but keeps the
@@ -33,17 +34,20 @@ class BaseCameraStream:
 
     # ------------------------------------------------------------------
     # _init_stream routine
+    @abstractmethod
     def _init_stream(self) -> None:
         """Set up the underlying capture device."""
-        pass
+        ...
 
     # _read_frame routine
+    @abstractmethod
     def _read_frame(self) -> Tuple[bool, Optional[np.ndarray]]:
-        raise NotImplementedError
+        ...
 
     # _release_stream routine
+    @abstractmethod
     def _release_stream(self) -> None:
-        pass
+        ...
 
     # ------------------------------------------------------------------
     # _capture_loop routine
@@ -74,8 +78,8 @@ class BaseCameraStream:
     def read(self) -> Tuple[bool, Optional[np.ndarray]]:
         return self.read_latest()
 
-    # isOpened routine
-    def isOpened(self) -> bool:
+    # is_opened routine
+    def is_opened(self) -> bool:
         return self.running and self.initialized
 
     # release routine

--- a/tests/test_capture_buffer.py
+++ b/tests/test_capture_buffer.py
@@ -5,6 +5,7 @@ import time
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -15,9 +16,9 @@ from modules.base_camera import BaseCameraStream
 # DummyStream class encapsulates dummystream behavior
 class DummyStream(BaseCameraStream):
     # __init__ routine
-    def __init__(self, fps=30, buffer_size=3):
+    def __init__(self, fps=30, buffer_size=3, start_thread=True):
         self.fps = fps
-        super().__init__(buffer_size)
+        super().__init__(buffer_size, start_thread=start_thread)
 
     # _init_stream routine
     def _init_stream(self):
@@ -44,5 +45,18 @@ def test_capture_buffer_latency():
         assert ret
         lag = time.time() - stream.last_ts
         lags.append(lag)
+    assert stream.is_opened()
     stream.release()
     assert max(lags) <= 3 / 30 + 0.1
+
+
+# Test abstract method enforcement and renamed API
+def test_base_camera_enforces_abstract_methods():
+    class BadStream(BaseCameraStream):
+        pass
+
+    with pytest.raises(TypeError):
+        BadStream()
+
+    stream = DummyStream(start_thread=False)
+    assert not hasattr(stream, "isOpened")

--- a/tests/test_local_camera.py
+++ b/tests/test_local_camera.py
@@ -3,12 +3,16 @@ from unittest.mock import patch
 
 
 def test_local_camera_windows_backend():
-    with patch.object(opencv_stream.BaseCameraStream, "__init__", return_value=None), \
-         patch.object(opencv_stream.platform, "system", return_value="Windows"), \
-         patch.object(opencv_stream.cv2, "VideoCapture") as mock_capture:
-        mock_capture.return_value.isOpened.return_value = True
-        stream = opencv_stream.OpenCVCameraStream("0")
-        stream.buffer_size = 3
-        stream._init_stream()
-        mock_capture.assert_called_once_with(0, opencv_stream.cv2.CAP_DSHOW)
+    def fake_init(self, src):
+        self.src = src
+
+    with patch.object(opencv_stream.BaseCameraStream, "__init__", fake_init), \
+         patch.object(opencv_stream.platform, "system", return_value="Windows"):
+        opencv_stream.cv2.CAP_DSHOW = 0
+        with patch.object(opencv_stream.cv2, "VideoCapture", create=True) as mock_capture:
+            mock_capture.return_value.isOpened.return_value = True
+            stream = opencv_stream.OpenCVCameraStream("0")
+            stream.buffer_size = 3
+            stream._init_stream()
+            mock_capture.assert_called_once_with(0, opencv_stream.cv2.CAP_DSHOW)
 


### PR DESCRIPTION
## Summary
- make `BaseCameraStream` an abstract base class requiring stream lifecycle methods
- rename `isOpened` to `is_opened`
- expand capture buffer tests to cover new API and abstract enforcement
- fix local camera test stubs

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'face_db' from 'modules')*
- `pytest tests/test_capture_buffer.py tests/test_local_camera.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b058194140832abb32b9ac15383888