### PR TITLE
feat: add app context dependency

### DIFF
--- a/core/context.py
+++ b/core/context.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from fastapi import Request
+from fastapi.templating import Jinja2Templates
+from redis import Redis
+
+
+@dataclass
+class AppContext:
+    """Container for shared application resources."""
+
+    config: dict
+    redis: Redis | None
+    trackers: Dict[int, Any]
+    templates: Jinja2Templates
+    branding: dict
+    cameras: List[dict]
+    redisfx: Any | None = None
+
+
+def get_app_context(request: Request) -> AppContext:
+    """Return application context from the FastAPI app state."""
+    ctx = getattr(request.state, "app_context", None)
+    if ctx is None:
+        app = request.app
+        ctx = AppContext(
+            config=getattr(app.state, "config", {}),
+            redis=getattr(app.state, "redis_client", None),
+            trackers=getattr(app.state, "trackers", {}),
+            templates=getattr(app.state, "templates"),
+            branding=getattr(app.state, "config", {}).get("branding", {}),
+            cameras=getattr(app.state, "cameras", []),
+            redisfx=getattr(app.state, "redis_facade", None),
+        )
+        request.state.app_context = ctx
+    return ctx

--- a/tests/routers/test_api_identities_context.py
+++ b/tests/routers/test_api_identities_context.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from fastapi.templating import Jinja2Templates
+
+from core.context import AppContext, get_app_context
+from routers import api_identities
+
+
+class FakeRedis:
+    def __init__(self):
+        self.data = {
+            "identity:abc": {
+                "name": "Alice",
+                "company": "ACME",
+                "tags": "vip",
+                "primary_face_id": "f1",
+            },
+            "identity:abc:faces": ["f1"],
+            "identity:abc:visits": ["2024"],
+            "identity:abc:cameras": {"1"},
+            "identity_face:f1": {"url": "/faces/f1.jpg"},
+        }
+
+    def hgetall(self, key):
+        return self.data.get(key, {})
+
+    def lrange(self, key, start, end):
+        return list(self.data.get(key, []))
+
+    def smembers(self, key):
+        return set(self.data.get(key, set()))
+
+    def hset(self, key, mapping):
+        self.data.setdefault(key, {}).update(mapping)
+
+    def lrem(self, key, count, value):
+        vals = [v for v in self.data.get(key, []) if v != value]
+        self.data[key] = vals
+
+    def delete(self, key):
+        self.data.pop(key, None)
+
+    def hget(self, key, field):
+        return self.data.get(key, {}).get(field)
+
+    def hdel(self, key, field):
+        if key in self.data:
+            self.data[key].pop(field, None)
+
+
+def create_app() -> TestClient:
+    app = FastAPI()
+    app.include_router(api_identities.router)
+    templates = Jinja2Templates(directory="templates")
+    ctx = AppContext(
+        config={},
+        redis=FakeRedis(),
+        trackers={},
+        templates=templates,
+        branding={},
+        cameras=[],
+    )
+    app.dependency_overrides[get_app_context] = lambda: ctx
+    return TestClient(app)
+
+
+def test_get_identity_uses_context():
+    client = create_app()
+    resp = client.get("/api/identities/abc")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "Alice"

--- a/tests/routers/test_reports_context.py
+++ b/tests/routers/test_reports_context.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from starlette.middleware.sessions import SessionMiddleware
+from fastapi.testclient import TestClient
+from fastapi.templating import Jinja2Templates
+
+from core.context import AppContext, get_app_context
+from routers import reports
+
+
+class FakeRedis:
+    def zcard(self, key):
+        return 0
+
+    def zrevrangebyscore(self, *args, **kwargs):
+        return []
+
+
+class FakeRedisFX:
+    async def call(self, *args, **kwargs):
+        return []
+
+
+def create_app() -> TestClient:
+    app = FastAPI()
+    app.add_middleware(SessionMiddleware, secret_key="test")
+    app.mount("/static", StaticFiles(directory="static"), name="static")
+    app.include_router(reports.router)
+    templates = Jinja2Templates(directory="templates")
+    ctx = AppContext(
+        config={"track_objects": ["person"], "count_classes": [], "branding": {}},
+        redis=FakeRedis(),
+        trackers={},
+        templates=templates,
+        branding={},
+        cameras=[{"id": 1, "archived": False}],
+        redisfx=FakeRedisFX(),
+    )
+    app.dependency_overrides[get_app_context] = lambda: ctx
+    return TestClient(app)
+
+
+def test_report_page_renders(monkeypatch):
+    client = create_app()
+    monkeypatch.setattr(reports, "require_roles", lambda request, roles: True)
+    resp = client.get("/report")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add `AppContext` dataclass and provider to centralize shared resources
- refactor identity and report routers to use injected `AppContext`
- cover routers with unit tests using mocked application context

## Testing
- `pytest tests/routers/test_api_identities_context.py tests/routers/test_reports_context.py`

------
https://chatgpt.com/codex/tasks/task_e_68b058171660832aa4e9f9beea03664a