### PR TITLE
Handle missing OpenCV on startup

### DIFF
--- a/modules/camera_factory.py
+++ b/modules/camera_factory.py
@@ -119,7 +119,7 @@ def _build(cam_cfg: dict[str, Any], cam_id: int) -> IFrameSource:
             uri, cam_id=cam_id, max_queue=cam_cfg.get("max_queue", 1)
         )
     if mode == "rtsp":
-        if config.get("use_gstreamer", use_gstreamer):
+        if config.get("use_gstreamer", use_gstreamer) and RtspGstSource is not None:
             return RtspGstSource(uri, tcp=tcp, latency_ms=latency, cam_id=cam_id)
         return RtspFfmpegSource(uri, tcp=tcp, latency_ms=latency, cam_id=cam_id)
     raise StreamUnavailable(f"unknown mode {mode}")
@@ -190,14 +190,18 @@ def open_capture(
 
     # rtsp with optional backend fallback
     if backend_priority is None:
-        if config.get("use_gstreamer", use_gstreamer):
+        if config.get("use_gstreamer", use_gstreamer) and RtspGstSource is not None:
             backend_priority = ["gst", "ffmpeg"]
-        else:
+        elif RtspGstSource is not None:
             backend_priority = ["ffmpeg", "gst"]
+        else:
+            backend_priority = ["ffmpeg"]
     while True:
         last_err = ""
         for be in backend_priority:
             if be == "gst":
+                if RtspGstSource is None:
+                    continue
                 cap = RtspGstSource(
                     str(src),
                     tcp=transport == "tcp",

--- a/modules/capture/__init__.py
+++ b/modules/capture/__init__.py
@@ -1,9 +1,18 @@
 """Unified capture sources."""
 
-from .base import IFrameSource, FrameSourceError, Backoff
+from .base import Backoff, FrameSourceError, IFrameSource
 from .local_cv import LocalCvSource
 from .rtsp_ffmpeg import RtspFfmpegSource
-from .rtsp_gst import RtspGstSource, ensure_gst
+
+try:  # pragma: no cover - optional dependency
+    from .rtsp_gst import RtspGstSource, ensure_gst
+except Exception:  # pragma: no cover - gstreamer/opencv missing
+    RtspGstSource = None  # type: ignore[assignment]
+
+    def ensure_gst() -> bool:
+        return False
+
+
 from .http_mjpeg import HttpMjpegSource
 
 __all__ = [

--- a/modules/duplicate_filter.py
+++ b/modules/duplicate_filter.py
@@ -2,7 +2,10 @@
 
 import time
 
-import cv2
+try:  # pragma: no cover - optional dependency
+    import cv2
+except Exception:  # pragma: no cover - opencv not available
+    cv2 = None  # type: ignore[assignment]
 import imagehash
 from PIL import Image
 
@@ -25,6 +28,8 @@ class DuplicateFilter:
 
     # is_duplicate routine
     def is_duplicate(self, frame) -> bool:
+        if cv2 is None:
+            return False
         img = Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)).resize((64, 64))
         ph = imagehash.phash(img)
         if self.prev is None:


### PR DESCRIPTION
## Summary
- Avoid hard OpenCV dependency in capture and duplicate filter modules
- Prefer FFMPEG when GStreamer/OpenCV is unavailable
- Skip duplicate frame checks when OpenCV is missing

## Testing
- `python3 -m pre_commit run --files modules/camera_factory.py modules/capture/__init__.py modules/duplicate_filter.py`
- `python3 -m pytest` *(fails: Interrupted: 34 errors during collection)*
- `python startup.py`


------
https://chatgpt.com/codex/tasks/task_e_68b066056504832aa801cfec75e14000