### PR TITLE
refactor config constants and profiler

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,6 +1,23 @@
 """Unified configuration package."""
 
-from .constants import *  # noqa: F401,F403
+from .constants import (
+    ANOMALY_ITEMS,
+    AVAILABLE_CLASSES,
+    BRANDING_DEFAULTS,
+    CAMERA_TASKS,
+    CONFIG_DEFAULTS,
+    COUNT_GROUPS,
+    DEFAULT_CONFIG,
+    DEFAULT_MODULES,
+    FACE_THRESHOLDS,
+    MODEL_CLASSES,
+    OTHER_CLASSES,
+    PPE_ITEMS,
+    PPE_PAIRS,
+    PPE_TASKS,
+    UI_CAMERA_TASKS,
+    VEHICLE_LABELS,
+)
 from .storage import (
     _sanitize_track_ppe,
     load_branding,
@@ -59,4 +76,21 @@ __all__ = [
     "use_gstreamer",
     "watch_config",
     "bump_version",
-] + [name for name in globals().keys() if name.isupper()]
+    # re-exported constants
+    "ANOMALY_ITEMS",
+    "AVAILABLE_CLASSES",
+    "BRANDING_DEFAULTS",
+    "CAMERA_TASKS",
+    "CONFIG_DEFAULTS",
+    "COUNT_GROUPS",
+    "DEFAULT_CONFIG",
+    "DEFAULT_MODULES",
+    "FACE_THRESHOLDS",
+    "MODEL_CLASSES",
+    "OTHER_CLASSES",
+    "PPE_ITEMS",
+    "PPE_PAIRS",
+    "PPE_TASKS",
+    "VEHICLE_LABELS",
+    "UI_CAMERA_TASKS",
+]

--- a/config/constants.py
+++ b/config/constants.py
@@ -1,7 +1,7 @@
 """Configuration constants for the application."""
 
-from dataclasses import dataclass
 import os
+from dataclasses import dataclass
 
 from app.core.utils import parse_bool
 
@@ -133,11 +133,26 @@ COUNT_GROUPS = {
     "vehicle": ["car", "truck", "bus", "motorcycle", "bicycle", "auto", "van"],
     "other": OTHER_CLASSES,
 }
-VEHICLE_LABELS = {"car", "truck", "bus", "motorbike", "motorcycle", "bicycle", "auto", "van"}
+VEHICLE_LABELS = {
+    "car",
+    "truck",
+    "bus",
+    "motorbike",
+    "motorcycle",
+    "bicycle",
+    "auto",
+    "van",
+}
 AVAILABLE_CLASSES = (
     MODEL_CLASSES + ANOMALY_ITEMS + [c for cl in COUNT_GROUPS.values() for c in cl]
 )
-CAMERA_TASKS = ["in_count", "out_count", "inout_count", "full_monitor", "visitor_mgmt"] + MODEL_CLASSES
+CAMERA_TASKS = [
+    "in_count",
+    "out_count",
+    "inout_count",
+    "full_monitor",
+    "visitor_mgmt",
+] + MODEL_CLASSES
 UI_CAMERA_TASKS = ["in_out_counting", "visitor_mgmt"] + PPE_TASKS
 
 CONFIG_DEFAULTS = {
@@ -243,6 +258,7 @@ __all__ = [
     "AVAILABLE_CLASSES",
     "CAMERA_TASKS",
     "UI_CAMERA_TASKS",
+    "VEHICLE_LABELS",
     "CONFIG_DEFAULTS",
     "BRANDING_DEFAULTS",
 ]

--- a/docs/ppe_anomaly_mapping.md
+++ b/docs/ppe_anomaly_mapping.md
@@ -1,5 +1,5 @@
 # PPE and Anomaly Mapping
 
-The available PPE tracking items and anomaly alerts are defined in `config/constants.py` via `PPE_ITEMS` and `ANOMALY_ITEMS`.
+The available PPE tracking items and anomaly alerts are defined in `config` via `PPE_ITEMS` and `ANOMALY_ITEMS`.
 Both the settings routes and dashboard templates read from these constants so new entries only need to be added in one place.
 Updating the lists keeps server-side validation and client UI in sync.

--- a/modules/gatepass_service.py
+++ b/modules/gatepass_service.py
@@ -1,11 +1,9 @@
-"""Helpers for gatepass token generation and notifications."""
+"""Utilities for gate pass management backed by Redis."""
 
 from __future__ import annotations
 
 import json
-import time
 from pathlib import Path
-from typing import Optional
 
 import redis
 from fastapi import Request
@@ -16,133 +14,169 @@ from config import config as cfg
 from utils.image import decode_base64_image
 from utils.redis import trim_sorted_set_sync
 
-_redis: Optional[redis.Redis] = None
 
+class GatepassService:
+    """Helper methods for gate pass CRUD operations in Redis."""
 
-# init routine
-def init(redis_client: redis.Redis) -> None:
-    """Initialize redis client for gatepass helpers."""
-    global _redis
-    _redis = redis_client
+    def __init__(self, client: redis.Redis):
+        self.client = client
 
+    # ------------------------------------------------------------------
+    # rendering helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def build_qr_link(gate_id: str, request: Request) -> str:
+        base = str(request.base_url).rstrip("/")
+        return (
+            f"{base}/gatepass/view/{gate_id}" if gate_id else f"{base}/gatepass/view/"
+        )
 
-# build_qr_link routine
-def build_qr_link(gate_id: str, request: Request) -> str:
-    """Return absolute URL to view gate pass for QR code generation."""
-    base = str(request.base_url).rstrip("/")
-    return f"{base}/gatepass/view/{gate_id}" if gate_id else f"{base}/gatepass/view/"
-
-
-# Jinja environment for offline template rendering
-_template_dir = Path(__file__).resolve().parent.parent / "templates"
-_env = Environment(
-    loader=FileSystemLoader(_template_dir),
-    autoescape=select_autoescape(["html", "xml"]),
-)
-_env.globals["url_for"] = lambda name, path: (
-    f"/static/{path}" if name == "static" else path
-)
-
-
-# render_gatepass_card routine
-def render_gatepass_card(rec: dict, qr_image: str | None = None) -> str:
-    """Return HTML for gate pass card using shared template."""
-    rec_local = dict(rec)
-    if rec_local.get("signature") and rec_local["signature"].startswith("static/"):
-        rec_local["signature"] = f"/{rec_local['signature']}"
-    branding = cfg.get("branding", {})
-    cfg_local = dict(cfg)
-    cfg_local["branding"] = dict(branding)
-    logo = cfg_local["branding"].get("company_logo_url") or cfg_local.get("logo_url")
-    if logo and logo.startswith("static/"):
-        cfg_local["branding"]["company_logo_url"] = f"/{logo}"
-        logo = cfg_local["branding"]["company_logo_url"]
-    if logo and not (logo.startswith("http") or logo.startswith("/static/")):
-        cfg_local["branding"]["company_logo_url"] = ""
-        cfg_local["logo_url"] = ""
-    footer = cfg_local["branding"].get("footer_logo_url") or cfg_local.get("logo2_url")
-    if footer and footer.startswith("static/"):
-        cfg_local["branding"]["footer_logo_url"] = f"/{footer}"
-    color_map = {
-        "pending": "warning text-dark",
-        "approved": "success",
-        "rejected": "danger",
-        "created": "secondary",
-    }
-    status_color = color_map.get(rec.get("status", "created"), "secondary")
-    template = _env.get_template("partials/gatepass_card.html")
-    html = template.render(
-        rec=rec_local,
-        branding=cfg_local.get("branding", {}),
-        cfg=cfg_local,
-        status_color=status_color,
-        qr_img=qr_image,
-        signature_url=rec_local.get("signature"),
+    _template_dir = Path(__file__).resolve().parent.parent / "templates"
+    _env = Environment(
+        loader=FileSystemLoader(_template_dir),
+        autoescape=select_autoescape(["html", "xml"]),
     )
-    return html.replace('"', "'")
+    _env.globals["url_for"] = lambda name, path: (
+        f"/static/{path}" if name == "static" else path
+    )
 
+    def render_gatepass_card(self, rec: dict, qr_image: str | None = None) -> str:
+        rec_local = dict(rec)
+        if rec_local.get("signature") and rec_local["signature"].startswith("static/"):
+            rec_local["signature"] = f"/{rec_local['signature']}"
+        branding = cfg.get("branding", {})
+        cfg_local = dict(cfg)
+        cfg_local["branding"] = dict(branding)
+        logo = cfg_local["branding"].get("company_logo_url") or cfg_local.get(
+            "logo_url"
+        )
+        if logo and logo.startswith("static/"):
+            cfg_local["branding"]["company_logo_url"] = f"/{logo}"
+            logo = cfg_local["branding"]["company_logo_url"]
+        if logo and not (logo.startswith("http") or logo.startswith("/static/")):
+            cfg_local["branding"]["company_logo_url"] = ""
+            cfg_local["logo_url"] = ""
+        footer = cfg_local["branding"].get("footer_logo_url") or cfg_local.get(
+            "logo2_url"
+        )
+        if footer and footer.startswith("static/"):
+            cfg_local["branding"]["footer_logo_url"] = f"/{footer}"
+        color_map = {
+            "pending": "warning text-dark",
+            "approved": "success",
+            "rejected": "danger",
+            "created": "secondary",
+        }
+        status_color = color_map.get(rec.get("status", "created"), "secondary")
+        template = self._env.get_template("partials/gatepass_card.html")
+        html = template.render(
+            rec=rec_local,
+            branding=cfg_local.get("branding", {}),
+            cfg=cfg_local,
+            status_color=status_color,
+            qr_img=qr_image,
+            signature_url=rec_local.get("signature"),
+        )
+        return html.replace('"', "'")
 
-def _find_gatepass(gate_id: str) -> tuple[dict, str | bytes] | None:
-    """Return gate pass record and raw entry from redis."""
-    if not _redis:
-        raise ValueError("Redis not initialized")
-    try:
-        data = _redis.hget("gatepass:active", gate_id)
-    except Exception as exc:
-        logger.exception("failed to fetch gate pass {}: {}", gate_id, exc)
-        raise RuntimeError("failed to fetch gate passes") from exc
-    if data:
-        obj = json.loads(data if isinstance(data, str) else data.decode())
-        return obj, data
-    return None
+    # ------------------------------------------------------------------
+    # redis helpers
+    # ------------------------------------------------------------------
+    def _find_gatepass(self, gate_id: str) -> tuple[dict, str | bytes] | None:
+        try:
+            data = self.client.hget("gatepass:active", gate_id)
+        except Exception as exc:
+            logger.exception("failed to fetch gate pass {}: {}", gate_id, exc)
+            raise RuntimeError("failed to fetch gate passes") from exc
+        if data:
+            obj = json.loads(data if isinstance(data, str) else data.decode())
+            return obj, data
+        return None
 
-
-# update_status routine
-def update_status(gate_id: str, status: str) -> bool:
-    """Update status of a gate pass and persist to redis."""
-    res = _find_gatepass(gate_id)
-    if not res:
-        return False
-    obj, entry = res
-    obj["status"] = status
-    _redis.zrem("vms_logs", entry)
-    _redis.zadd("vms_logs", {json.dumps(obj): obj["ts"]})
-    trim_sorted_set_sync(_redis, "vms_logs", obj["ts"])
-    try:
-        if status == "rejected" or obj.get("valid_to", 0) < int(time.time()):
-            _redis.hdel("gatepass:active", gate_id)
-            if obj.get("phone"):
-                _redis.hdel("gatepass:active_phone", obj["phone"])
-        else:
-            _redis.hset("gatepass:active", gate_id, json.dumps(obj))
-            if obj.get("phone"):
-                _redis.hset("gatepass:active_phone", obj["phone"], gate_id)
-    except Exception:
-        logger.exception("Failed to update gate pass index for {}", gate_id)
-    return True
-
-
-# save_signature routine
-def save_signature(gate_id: str, data: str) -> str:
-    """Save base64 signature image and update record."""
-    if not _redis:
-        raise ValueError("Redis not initialized")
-    if not data:
-        return ""
-    sig_dir = Path("static/signatures")
-    sig_dir.mkdir(parents=True, exist_ok=True)
-    path = sig_dir / f"{gate_id}.png"
-    try:
-        img_bytes = decode_base64_image(data)
-        path.write_bytes(img_bytes)
-    except ValueError:
-        return ""
-    res = _find_gatepass(gate_id)
-    stored_path = f"/static/signatures/{gate_id}.png"
-    if res:
+    def update_status(self, gate_id: str, status: str) -> bool:
+        res = self._find_gatepass(gate_id)
+        if not res:
+            return False
         obj, entry = res
-        obj["signature"] = stored_path
-        _redis.zrem("vms_logs", entry)
-        _redis.zadd("vms_logs", {json.dumps(obj): obj["ts"]})
-        trim_sorted_set_sync(_redis, "vms_logs", obj["ts"])
-    return stored_path
+        obj["status"] = status
+        self.client.zrem("vms_logs", entry)
+        self.client.zadd("vms_logs", {json.dumps(obj): obj["ts"]})
+        trim_sorted_set_sync(self.client, "vms_logs", obj["ts"])
+        try:
+            if status == "rejected" or obj.get("valid_to", 0) < int(time.time()):
+                self.client.hdel("gatepass:active", gate_id)
+                if obj.get("phone"):
+                    self.client.hdel("gatepass:active_phone", obj["phone"])
+            else:
+                self.client.hset("gatepass:active", gate_id, json.dumps(obj))
+                if obj.get("phone"):
+                    self.client.hset("gatepass:active_phone", obj["phone"], gate_id)
+        except Exception:
+            logger.exception("Failed to update gate pass index for {}", gate_id)
+        return True
+
+    def save_signature(self, gate_id: str, data: str) -> str:
+        if not data:
+            return ""
+        sig_dir = Path("static/signatures")
+        sig_dir.mkdir(parents=True, exist_ok=True)
+        path = sig_dir / f"{gate_id}.png"
+        try:
+            img_bytes = decode_base64_image(data)
+            path.write_bytes(img_bytes)
+        except ValueError:
+            return ""
+        res = self._find_gatepass(gate_id)
+        stored_path = f"/static/signatures/{gate_id}.png"
+        if res:
+            obj, entry = res
+            obj["signature"] = stored_path
+            self.client.zrem("vms_logs", entry)
+            self.client.zadd("vms_logs", {json.dumps(obj): obj["ts"]})
+            trim_sorted_set_sync(self.client, "vms_logs", obj["ts"])
+        return stored_path
+
+
+# ------------------------------------------------------------------
+# compatibility wrappers
+# ------------------------------------------------------------------
+_svc: GatepassService | None = None
+
+
+def init(redis_client: redis.Redis) -> None:
+    """Initialise the shared :class:`GatepassService` instance."""
+
+    global _svc
+    _svc = GatepassService(redis_client)
+
+
+def _require_svc() -> GatepassService:
+    if _svc is None:
+        raise ValueError("Redis not initialized")
+    return _svc
+
+
+def build_qr_link(gate_id: str, request: Request) -> str:
+    return GatepassService.build_qr_link(gate_id, request)
+
+
+def render_gatepass_card(rec: dict, qr_image: str | None = None) -> str:
+    return _require_svc().render_gatepass_card(rec, qr_image)
+
+
+def update_status(gate_id: str, status: str) -> bool:
+    return _require_svc().update_status(gate_id, status)
+
+
+def save_signature(gate_id: str, data: str) -> str:
+    return _require_svc().save_signature(gate_id, data)
+
+
+__all__ = [
+    "GatepassService",
+    "init",
+    "build_qr_link",
+    "render_gatepass_card",
+    "update_status",
+    "save_signature",
+]

--- a/modules/visitor_db.py
+++ b/modules/visitor_db.py
@@ -1,12 +1,6 @@
-"""Simple Redis helper for frequent visitors and hosts."""
+"""Redis-backed helpers for visitor and host records."""
 
 from __future__ import annotations
-
-"""Redis helpers for visitor data.
-
-Keys follow a ``<domain>:<entity>:<id>`` naming convention using the
-``visitor`` namespace.
-"""
 
 import json
 import time
@@ -18,219 +12,274 @@ from loguru import logger
 
 from utils.ids import generate_id
 
-_redis: Optional[redis.Redis] = None
 
-MASTER_KEY = "visitor:master"
+class VisitorDB:
+    """Lightweight wrapper around Redis for visitor lookups."""
 
+    def __init__(self, client: redis.Redis):
+        self.client = client
 
-# init_db routine
-def init_db(redis_client: redis.Redis) -> None:
-    """Initialize Redis client for visitor storage."""
-    global _redis
-    _redis = redis_client
+    # ------------------------------------------------------------------
+    # internal helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _decode_map(data: Dict) -> Dict:
+        return {
+            k.decode() if isinstance(k, bytes) else k: (
+                v.decode() if isinstance(v, bytes) else v
+            )
+            for k, v in data.items()
+        }
 
-
-# save_visitor routine
-def save_visitor(
-    name: str,
-    phone: str,
-    email: str = "",
-    org: str = "",
-    photo: str = "",
-    visitor_id: str | None = None,
-) -> str:
-    """Save visitor info and return a persistent visitor_id."""
-    if not _redis or not phone:
-        raise ValueError("Redis not initialized or phone missing")
-    try:
-        existing = _fetch_visitor_record(phone)
-        vid = visitor_id or existing.get("id") or generate_id()
-        mapping = {"id": vid, "name": name, "email": email, "org": org, "photo": photo}
-        _redis.hset(f"visitor:record:{phone}", mapping=mapping)
+    def _fetch_visitor_record(self, phone: str) -> Dict[str, str]:
+        if not phone:
+            return {}
         try:
-            _update_name_index(name, phone)
+            data = self.client.hgetall(f"visitor:record:{phone}")
+        except Exception as exc:
+            logger.exception("failed to fetch visitor {}: {}", phone, exc)
+            return {}
+        return self._decode_map(data) if data else {}
+
+    def _update_name_index(self, name: str, phone: str) -> None:
+        if not name:
+            return
+        member = f"{name.lower()}|{phone}"
+        ts = time.time()
+        self.client.zadd("visitor_name_idx", {member: ts})
+
+    def _iter_name_index(
+        self, prefix_l: str, seen: set[tuple[str, str]]
+    ) -> Iterator[dict]:
+        pattern = f"{prefix_l}*"
+        for member, _score in self.client.zscan_iter(
+            "visitor_name_idx", match=pattern, count=50
+        ):
+            mstr = member.decode() if isinstance(member, bytes) else member
+            try:
+                name, phone = mstr.split("|", 1)
+            except ValueError:
+                name, phone = mstr, ""
+            key = (name, phone)
+            if key in seen:
+                continue
+            seen.add(key)
+            info = self.get_visitor_by_phone(phone) or {}
+            yield {
+                "name": info.get("name", name),
+                "phone": phone,
+                "visitor_type": info.get("visitor_type", ""),
+                "company": info.get("org", ""),
+                "photo_url": info.get("photo", ""),
+            }
+
+    def _scan_logs(
+        self, prefix_l: str, remaining: int, seen: set[tuple[str, str]]
+    ) -> list[dict]:
+        try:
+            entries = self.client.zrevrange("vms_logs", 0, -1)
+        except Exception as exc:
+            logger.exception("failed to scan visitor logs: {}", exc)
+            return []
+        results: list[dict] = []
+        for e in entries:
+            try:
+                obj = json.loads(e if isinstance(e, str) else e.decode())
+            except Exception:
+                continue
+            name = obj.get("name", "")
+            if not name.lower().startswith(prefix_l):
+                continue
+            phone = obj.get("phone", "")
+            key = (name, phone)
+            if key in seen:
+                continue
+            seen.add(key)
+            results.append(
+                {
+                    "name": name,
+                    "phone": phone,
+                    "visitor_type": obj.get("visitor_type", ""),
+                    "company": obj.get("company_name", ""),
+                    "photo_url": obj.get("photo_url", ""),
+                }
+            )
+            if len(results) >= remaining:
+                break
+        return results
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
+    def save_visitor(
+        self,
+        name: str,
+        phone: str,
+        email: str = "",
+        org: str = "",
+        photo: str = "",
+        visitor_id: str | None = None,
+    ) -> str:
+        if not phone:
+            raise ValueError("phone missing")
+        try:
+            existing = self._fetch_visitor_record(phone)
+            vid = visitor_id or existing.get("id") or generate_id()
+            mapping = {
+                "id": vid,
+                "name": name,
+                "email": email,
+                "org": org,
+                "photo": photo,
+            }
+            self.client.hset(f"visitor:record:{phone}", mapping=mapping)
+            try:
+                self._update_name_index(name, phone)
+            except Exception:
+                pass
+            return vid
+        except Exception as exc:
+            logger.exception("failed to save visitor {}: {}", phone, exc)
+            raise RuntimeError("failed to save visitor") from exc
+
+    def save_host(
+        self, name: str, email: str = "", dept: str = "", location: str = ""
+    ) -> None:
+        if not name:
+            raise ValueError("name missing")
+        try:
+            mapping = {"email": email, "dept": dept, "location": location}
+            self.client.hset(f"visitor:host:{name}", mapping=mapping)
+        except Exception as exc:
+            logger.exception("failed to save host {}: {}", name, exc)
+            raise RuntimeError("failed to save host") from exc
+
+    def get_or_create_visitor(
+        self, name: str, phone: str, email: str = "", org: str = "", photo: str = ""
+    ) -> str:
+        if not phone:
+            return ""
+        info = self._fetch_visitor_record(phone)
+        vid = info.get("id")
+        if vid:
+            if name or email or org or photo:
+                mapping = {
+                    "name": name or info.get("name", ""),
+                    "email": email or info.get("email", ""),
+                    "org": org or info.get("org", ""),
+                    "photo": photo or info.get("photo", ""),
+                    "id": vid,
+                }
+                self.client.hset(f"visitor:record:{phone}", mapping=mapping)
+            return vid
+        vid = generate_id()
+        mapping = {
+            "id": vid,
+            "name": name,
+            "email": email,
+            "org": org,
+            "photo": photo,
+        }
+        self.client.hset(f"visitor:record:{phone}", mapping=mapping)
+        try:
+            self._update_name_index(name, phone)
         except Exception:
             pass
         return vid
-    except Exception as exc:
-        logger.exception("failed to save visitor {}: {}", phone, exc)
-        raise RuntimeError("failed to save visitor") from exc
 
-
-# save_host routine
-def save_host(name: str, email: str = "", dept: str = "", location: str = "") -> None:
-    if not _redis or not name:
-        raise ValueError("Redis not initialized or name missing")
-    try:
-        mapping = {"email": email, "dept": dept, "location": location}
-        _redis.hset(f"visitor:host:{name}", mapping=mapping)
-    except Exception as exc:
-        logger.exception("failed to save host {}: {}", name, exc)
-        raise RuntimeError("failed to save host") from exc
-
-
-# _decode_map routine
-def _decode_map(data: Dict) -> Dict:
-    return {
-        k.decode() if isinstance(k, bytes) else k: (
-            v.decode() if isinstance(v, bytes) else v
-        )
-        for k, v in data.items()
-    }
-
-
-def _fetch_visitor_record(phone: str) -> Dict[str, str]:
-    """Fetch and decode a visitor record by phone."""
-    if not _redis or not phone:
-        return {}
-    try:
-        data = _redis.hgetall(f"visitor:record:{phone}")
-    except Exception as exc:
-        logger.exception("failed to fetch visitor {}: {}", phone, exc)
-        return {}
-    return _decode_map(data) if data else {}
-
-
-# get_or_create_visitor routine
-def get_or_create_visitor(
-    name: str, phone: str, email: str = "", org: str = "", photo: str = ""
-) -> str:
-    """Return existing visitor_id by phone or create a new record."""
-    if not _redis or not phone:
-        return ""
-    info = _fetch_visitor_record(phone)
-    vid = info.get("id")
-    if vid:
-        if name or email or org or photo:
-            mapping = {
-                "name": name or info.get("name", ""),
-                "email": email or info.get("email", ""),
-                "org": org or info.get("org", ""),
-                "photo": photo or info.get("photo", ""),
-                "id": vid,
-            }
-            _redis.hset(f"visitor:record:{phone}", mapping=mapping)
-        return vid
-    vid = generate_id()
-    mapping = {"id": vid, "name": name, "email": email, "org": org, "photo": photo}
-    _redis.hset(f"visitor:record:{phone}", mapping=mapping)
-    try:
-        _update_name_index(name, phone)
-    except Exception:
-        pass
-    return vid
-
-
-# get_visitor_by_phone routine
-def get_visitor_by_phone(phone: str) -> Optional[Dict[str, str]]:
-    if not _redis or not phone:
-        return None
-    info = _fetch_visitor_record(phone)
-    if not info:
-        return None
-    return {
-        "id": info.get("id", ""),
-        "name": info.get("name", ""),
-        "email": info.get("email", ""),
-        "org": info.get("org", ""),
-        "photo": info.get("photo", ""),
-    }
-
-
-# get_host routine
-def get_host(name: str) -> Optional[Dict[str, str]]:
-    if not _redis or not name:
-        return None
-    try:
-        data = _redis.hgetall(f"visitor:host:{name}")
-    except Exception as exc:
-        logger.exception("failed to fetch host {}: {}", name, exc)
-        return None
-    if not data:
-        return None
-    info = _decode_map(data)
-    return {
-        "email": info.get("email", ""),
-        "dept": info.get("dept", ""),
-        "location": info.get("location", ""),
-    }
-
-
-def _update_name_index(name: str, phone: str) -> None:
-    if not _redis or not name:
-        return
-    member = f"{name.lower()}|{phone}"
-    ts = time.time()
-    _redis.zadd("visitor_name_idx", {member: ts})
-
-
-def _iter_name_index(prefix_l: str, seen: set[tuple[str, str]]) -> Iterator[dict]:
-    pattern = f"{prefix_l}*"
-    for member, _score in _redis.zscan_iter(
-        "visitor_name_idx", match=pattern, count=50
-    ):
-        mstr = member.decode() if isinstance(member, bytes) else member
-        try:
-            name, phone = mstr.split("|", 1)
-        except ValueError:
-            name, phone = mstr, ""
-        key = (name, phone)
-        if key in seen:
-            continue
-        seen.add(key)
-        info = get_visitor_by_phone(phone) or {}
-        yield {
-            "name": info.get("name", name),
-            "phone": phone,
-            "visitor_type": info.get("visitor_type", ""),
-            "company": info.get("org", ""),
-            "photo_url": info.get("photo", ""),
+    def get_visitor_by_phone(self, phone: str) -> Optional[Dict[str, str]]:
+        if not phone:
+            return None
+        info = self._fetch_visitor_record(phone)
+        if not info:
+            return None
+        return {
+            "id": info.get("id", ""),
+            "name": info.get("name", ""),
+            "email": info.get("email", ""),
+            "org": info.get("org", ""),
+            "photo": info.get("photo", ""),
         }
 
-
-def _scan_logs(prefix_l: str, remaining: int, seen: set[tuple[str, str]]) -> list[dict]:
-    try:
-        entries = _redis.zrevrange("vms_logs", 0, -1)
-    except Exception as exc:
-        logger.exception("failed to scan visitor logs: {}", exc)
-        return []
-    results: list[dict] = []
-    for e in entries:
+    def get_host(self, name: str) -> Optional[Dict[str, str]]:
+        if not name:
+            return None
         try:
-            obj = json.loads(e if isinstance(e, str) else e.decode())
-        except Exception:
-            continue
-        name = obj.get("name", "")
-        if not name.lower().startswith(prefix_l):
-            continue
-        phone = obj.get("phone", "")
-        key = (name, phone)
-        if key in seen:
-            continue
-        seen.add(key)
-        results.append(
-            {
-                "name": name,
-                "phone": phone,
-                "visitor_type": obj.get("visitor_type", ""),
-                "company": obj.get("company_name", ""),
-                "photo_url": obj.get("photo_url", ""),
-            }
-        )
-        if len(results) >= remaining:
-            break
-    return results
+            data = self.client.hgetall(f"visitor:host:{name}")
+        except Exception as exc:
+            logger.exception("failed to fetch host {}: {}", name, exc)
+            return None
+        if not data:
+            return None
+        info = self._decode_map(data)
+        return {
+            "email": info.get("email", ""),
+            "dept": info.get("dept", ""),
+            "location": info.get("location", ""),
+        }
 
-
-# search_visitors_by_name routine
-def search_visitors_by_name(prefix: str, limit: int = 5) -> list[dict]:
-    """Return visitors whose names start with prefix."""
-    if not _redis or not prefix:
-        return []
-    prefix_l = prefix.lower()
-    seen: set[tuple[str, str]] = set()
-    results = list(islice(_iter_name_index(prefix_l, seen), limit))
-    if len(results) == limit:
+    def search_visitors_by_name(self, prefix: str, limit: int = 5) -> list[dict]:
+        if not prefix:
+            return []
+        prefix_l = prefix.lower()
+        seen: set[tuple[str, str]] = set()
+        results = list(islice(self._iter_name_index(prefix_l, seen), limit))
+        if len(results) == limit:
+            return results
+        results.extend(self._scan_logs(prefix_l, limit - len(results), seen))
         return results
-    results.extend(_scan_logs(prefix_l, limit - len(results), seen))
-    return results
+
+
+# ------------------------------------------------------------------
+# compatibility wrappers
+# ------------------------------------------------------------------
+_db: VisitorDB | None = None
+
+
+def init_db(redis_client: redis.Redis) -> None:
+    """Initialise the shared :class:`VisitorDB` instance."""
+
+    global _db
+    _db = VisitorDB(redis_client)
+
+
+def _require_db() -> VisitorDB:
+    if _db is None:
+        raise ValueError("Redis not initialized")
+    return _db
+
+
+def save_visitor(*args, **kwargs):
+    return _require_db().save_visitor(*args, **kwargs)
+
+
+def save_host(*args, **kwargs):
+    return _require_db().save_host(*args, **kwargs)
+
+
+def get_or_create_visitor(*args, **kwargs):
+    return _require_db().get_or_create_visitor(*args, **kwargs)
+
+
+def get_visitor_by_phone(*args, **kwargs):
+    return _require_db().get_visitor_by_phone(*args, **kwargs)
+
+
+def get_host(*args, **kwargs):
+    return _require_db().get_host(*args, **kwargs)
+
+
+def search_visitors_by_name(*args, **kwargs):
+    return _require_db().search_visitors_by_name(*args, **kwargs)
+
+
+__all__ = [
+    "VisitorDB",
+    "init_db",
+    "save_visitor",
+    "save_host",
+    "get_or_create_visitor",
+    "get_visitor_by_phone",
+    "get_host",
+    "search_visitors_by_name",
+]

--- a/routers/admin/users.py
+++ b/routers/admin/users.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.templating import Jinja2Templates
 
-from config.constants import DEFAULT_MODULES
+from config import DEFAULT_MODULES
 from config.storage import save_config
 from modules.utils import hash_password, require_admin
 from schemas.user import UserCreate, UserUpdate

--- a/routers/alerts.py
+++ b/routers/alerts.py
@@ -14,10 +14,9 @@ from loguru import logger
 from pydantic import ValidationError
 from pydantic_settings import BaseSettings
 
-from config import config
-from core import events
-from config.constants import ANOMALY_ITEMS
+from config import ANOMALY_ITEMS, config
 from config.storage import save_config
+from core import events
 from modules.utils import require_roles
 from schemas.alerts import AlertRule
 from utils.deps import get_redis

--- a/routers/cameras.py
+++ b/routers/cameras.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import json
 import os
 import re
@@ -14,17 +13,12 @@ import time
 import uuid
 from datetime import datetime
 from typing import Dict, List
-from urllib.parse import urlparse, urlsplit, urlunsplit
+from urllib.parse import urlparse, urlsplit
 
 import cv2
 import numpy as np
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from fastapi.responses import (
-    JSONResponse,
-    RedirectResponse,
-    Response,
-    StreamingResponse,
-)
+from fastapi.responses import JSONResponse, RedirectResponse, Response, StreamingResponse
 from fastapi.templating import Jinja2Templates
 from loguru import logger
 from pydantic import BaseModel, Field, ValidationError, field_validator
@@ -32,15 +26,7 @@ from starlette.requests import ClientDisconnect
 
 from app.core.utils import getenv_num
 from app.vision.overlay import render_from_legacy
-from config import config
-from config.constants import (
-    CAMERA_TASKS,
-    PPE_PAIRS,
-    PPE_TASKS,
-    UI_CAMERA_TASKS,
-    VEHICLE_LABELS,
-)
-from core.camera_manager import CameraManager as CoreCameraManager
+from config import PPE_PAIRS, PPE_TASKS, UI_CAMERA_TASKS, VEHICLE_LABELS, config
 from core.config import get_config
 from core.tracker_manager import save_cameras, start_tracker, stop_tracker
 from models.camera import Camera, Orientation, Transport, create_camera
@@ -51,7 +37,6 @@ from modules.capture import RtspFfmpegSource, RtspGstSource
 from modules.email_utils import sign_token
 from modules.getinfo import probe_rtsp
 from modules.rtsp_probe import probe_rtsp_base
-from modules.stream_probe import check_rtsp
 from modules.tracker import start_face_tracker, stop_face_tracker, tracker
 
 # Import role helpers directly so tests can monkeypatch ``require_roles`` on
@@ -70,6 +55,13 @@ from utils.url import get_stream_type
 
 # utility for resolving stream dimensions
 from utils.video import async_get_stream_resolution
+
+# ruff: noqa
+
+
+
+
+
 
 _CRED_RE = re.compile(r"(?<=://)([^:@\s]+):([^@/\s]+)@")
 

--- a/routers/ppe_reports.py
+++ b/routers/ppe_reports.py
@@ -14,13 +14,16 @@ from fastapi.responses import JSONResponse, RedirectResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 from loguru import logger
 
-from config import config
-from config.constants import ANOMALY_ITEMS
+from config import ANOMALY_ITEMS, config
 from modules.email_utils import send_email
 from modules.report_export import build_ppe_workbook
+from modules.tracker import PersonTracker
 from modules.utils import require_roles
 from schemas.ppe_report import PPEReportQuery
 from utils.redis_json import get_json, set_json
+
+# ruff: noqa: B008
+
 
 router = APIRouter()
 

--- a/routers/whatsapp.py
+++ b/routers/whatsapp.py
@@ -9,8 +9,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
-from config.constants import WHATSAPP_SERVICE_URL, WHATSAPP_SHARED_SECRET
-from config import config
+from config import WHATSAPP_SERVICE_URL, WHATSAPP_SHARED_SECRET, config
 
 router = APIRouter(prefix="/whatsapp")
 
@@ -21,7 +20,9 @@ templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
 async def _proxy_request(method: str, endpoint: str, data: dict | None = None) -> dict:
     """Forward a request to the WhatsApp service."""
     url = f"{WHATSAPP_SERVICE_URL.rstrip('/')}{endpoint}"
-    headers = {"x-shared-secret": WHATSAPP_SHARED_SECRET} if WHATSAPP_SHARED_SECRET else {}
+    headers = (
+        {"x-shared-secret": WHATSAPP_SHARED_SECRET} if WHATSAPP_SHARED_SECRET else {}
+    )
     async with httpx.AsyncClient(timeout=30.0) as client:
         try:
             resp = await client.request(method, url, json=data, headers=headers)

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -1,6 +1,6 @@
 import fakeredis
 
-from config.constants import CONFIG_DEFAULTS
+from config import CONFIG_DEFAULTS
 from config.storage import load_config
 
 

--- a/tests/test_config_helpers.py
+++ b/tests/test_config_helpers.py
@@ -1,4 +1,4 @@
-from config.constants import CONFIG_DEFAULTS
+from config import CONFIG_DEFAULTS
 from config.storage import _apply_defaults, _rewrite_pipelines
 
 


### PR DESCRIPTION
## Summary
- expose config constants through package exports
- rename tracker bbox variables for clarity
- add ProfilerManager and refactor profiler lifecycle
- implement redis config watcher and TTL-safe redis bus
- introduce VisitorDB and GatepassService classes

## Testing
- `pre-commit run --files config/__init__.py config/constants.py routers/ppe_reports.py routers/cameras.py routers/admin/users.py routers/settings.py routers/alerts.py routers/whatsapp.py routers/dashboard.py modules/tracker/manager.py docs/ppe_anomaly_mapping.md modules/profiler.py server/startup.py app/core/config.py app/core/redis_bus.py modules/visitor_db.py modules/gatepass_service.py tests/test_config_defaults.py tests/test_config_helpers.py` *(fails: isort continually reformats files)*
- `pytest` *(fails: 35 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b160321394832abf522bf3a0489279