### PR TITLE
Refactor logging and lifecycle management

### DIFF
--- a/logging_config.py
+++ b/logging_config.py
@@ -30,14 +30,13 @@ _sink_ids: list[int] = []
 
 
 def _configure(level: str = LOG_LEVEL) -> None:
-    """Configure Loguru sinks with structured JSON output in a thread-safe manner."""
+    """Configure Loguru sinks with structured JSON output."""
     global _sink_ids
     with _lock:
         for sink_id in _sink_ids:
             try:
                 logger.remove(sink_id)
             except ValueError:
-                # Sink might have been removed elsewhere; ignore missing handlers
                 continue
         _sink_ids = [
             logger.add(
@@ -76,9 +75,13 @@ def _configure(level: str = LOG_LEVEL) -> None:
         )
 
 
+def setup_json_logger(level: str = LOG_LEVEL) -> None:
+    """Initialise structured logging sinks."""
+    _configure(level)
+
+
 def set_log_level(level: str) -> None:
     """Update logger level at runtime."""
     _configure(level)
 
 
-_configure()

--- a/modules/pipeline.py
+++ b/modules/pipeline.py
@@ -6,12 +6,7 @@ from typing import Deque, Optional
 
 import numpy as np
 
-from app.core.lifecycle import (
-    StoppableThread,
-    register_pipeline,
-    register_signal_handlers,
-    unregister_pipeline,
-)
+from app.core.lifecycle import StoppableThread, lifecycle_manager
 from app.core.utils import getenv_num
 
 try:
@@ -89,14 +84,14 @@ class Pipeline:
 
     def start(self) -> None:
         """Start capture and processing threads."""
-        register_signal_handlers()
-        register_pipeline(self)
+        lifecycle_manager.register_signal_handlers()
+        lifecycle_manager.register_pipeline(self)
         self.capture.start()
         self.process.start()
 
     def stop(self) -> None:
         """Stop all threads."""
-        unregister_pipeline(self)
+        lifecycle_manager.unregister_pipeline(self)
         self.capture.stop()
         self.process.stop()
         self.capture.join(timeout=2.0)

--- a/modules/troubleshooter_runner.py
+++ b/modules/troubleshooter_runner.py
@@ -3,14 +3,17 @@ from __future__ import annotations
 import json
 import multiprocessing as mp
 import os
+import shutil
 import subprocess
 import threading
 import time
 import uuid
-from typing import Dict, Any
+from typing import Any, Dict
 from urllib.parse import urlparse
-import shutil
 
+from loguru import logger
+
+logger = logger.bind(module="troubleshooter")
 
 # Map of active runs: run_id -> {"queue": mp.Queue, "process": mp.Process}
 _RUNS: Dict[str, Dict[str, Any]] = {}
@@ -43,8 +46,7 @@ def _run_stage(name: str, func, queue: mp.Queue, timeout: float = 10.0) -> bool:
         "duration_ms": duration_ms,
         "detail": detail,
     }
-    # emit compact JSON log line
-    print(json.dumps(event), flush=True)
+    logger.info(json.dumps(event))
     queue.put(event)
     return status == "PASS"
 

--- a/server/startup.py
+++ b/server/startup.py
@@ -15,7 +15,6 @@ from loguru import logger
 from redis import Redis
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-import logging_config  # noqa: F401
 from config import load_branding, load_config, save_config
 from config.license_storage import get as load_license
 from config.license_storage import set as save_license
@@ -31,10 +30,12 @@ from utils.gpu import configure_onnxruntime
 from utils.gstreamer import probe_gstreamer
 from utils.preflight import DependencyError, check_dependencies
 from utils.redis_facade import make_facade_from_url
+from logging_config import LOG_LEVEL, set_log_level, setup_json_logger
 
 from .config import _apply_license, _connect_redis, _load_camera_profiles, _read_initial_config
 from .hardware import _early_cpu_setup
 
+setup_json_logger()
 logger = logger.bind(module="startup")
 
 # perform CPU setup before heavy imports
@@ -167,7 +168,7 @@ def init_app(
         raise SystemExit(1) from e
     cfg["secret_key"] = os.getenv("CSRF_SECRET_KEY", cfg.get("secret_key", ""))
 
-    logging_config.set_log_level(cfg.get("log_level", logging_config.LOG_LEVEL))
+    set_log_level(cfg.get("log_level", LOG_LEVEL))
     probe_gstreamer(cfg)
 
     branding_path = str(Path(config_path_local).with_name("branding.json"))

--- a/tests/test_counting.py
+++ b/tests/test_counting.py
@@ -1,14 +1,6 @@
 import importlib
-import sys
-from pathlib import Path
 
-# Add app directory to path so ``vision`` package can be imported without
-# interfering with existing ``app.py`` module.
-APP_DIR = Path(__file__).resolve().parents[1] / "app"
-if str(APP_DIR) not in sys.path:
-    sys.path.insert(0, str(APP_DIR))
-
-counting = importlib.import_module("vision.counting")
+counting = importlib.import_module("app.vision.counting")
 
 
 def test_side_of_line():

--- a/tests/test_lifecycle_manager.py
+++ b/tests/test_lifecycle_manager.py
@@ -1,0 +1,30 @@
+import signal
+import time
+import types
+
+import pytest
+
+from app.core.lifecycle import LifecycleManager
+
+
+def test_register_signal_handlers_idempotent(monkeypatch):
+    mgr = LifecycleManager()
+    calls = []
+
+    def fake_signal(sig, handler):
+        calls.append(sig)
+
+    monkeypatch.setattr("signal.signal", fake_signal)
+    mgr.register_signal_handlers()
+    mgr.register_signal_handlers()
+    assert calls.count(signal.SIGINT) == 1
+    assert calls.count(signal.SIGTERM) == 1
+
+
+def test_watchdog_start_stop():
+    mgr = LifecycleManager()
+    dummy = types.SimpleNamespace(process=types.SimpleNamespace(last_processed_ts=time.time()), cam_cfg={})
+    mgr.register_pipeline(dummy)
+    assert mgr._watchdog is not None
+    mgr.unregister_pipeline(dummy)
+    assert mgr._watchdog is None

--- a/tests/test_troubleshooter_runner.py
+++ b/tests/test_troubleshooter_runner.py
@@ -1,7 +1,12 @@
 import json
+import multiprocessing as mp
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from loguru import logger
 import routers.troubleshooter as ts
+
+from modules.troubleshooter_runner import _run_stage
 
 
 def _cameras():
@@ -36,3 +41,11 @@ def test_troubleshooter_runner_stream(monkeypatch):
     stages = [e["stage"] for e in events]
     assert stages[0] == "ping"
     assert stages[-1] == "complete"
+
+
+def test_run_stage_logs(caplog):
+    logger.remove()
+    logger.add(caplog.handler, level="INFO")
+    q = mp.Queue()
+    assert _run_stage("test", lambda: None, q)
+    assert '"stage": "test"' in caplog.text

--- a/vision/__init__.py
+++ b/vision/__init__.py
@@ -1,1 +1,0 @@
-"""Vision helpers."""

--- a/vision/counting.py
+++ b/vision/counting.py
@@ -1,9 +1,0 @@
-"""Compatibility wrapper for legacy imports.
-
-This module re-exports the counting helpers from :mod:`app.vision.counting` so
-that tests or callers importing ``vision.counting`` continue to function even
-if the application package layout changes.
-"""
-
-from app.vision.counting import *  # noqa: F401,F403
-


### PR DESCRIPTION
## Summary
- configure logging via explicit `setup_json_logger` call
- replace Redis exception handling with explicit `RedisError` logging and cached client
- introduce `LifecycleManager` for signal/watchdog control and exercise via tests
- log troubleshooter events with structured logger
- remove legacy `vision` shim and update counting tests

## Testing
- `pytest tests/test_logging_config_thread_safe.py tests/test_logx.py tests/test_lifecycle_manager.py tests/test_troubleshooter_runner.py tests/test_counting.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1719ec5dc832aa9abb2736fa64146