### PR TITLE
chore(ci): use upload-artifact v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,13 @@ jobs:
             --cov=. --cov-report=xml
       - name: Upload JUnit results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: unit-test-results
           path: unit-tests.xml
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: unit-coverage
           path: coverage.xml
@@ -117,13 +117,13 @@ jobs:
             --cov=. --cov-report=xml
       - name: Upload JUnit results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: integration-test-results
           path: integration-tests.xml
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: integration-coverage
           path: coverage.xml


### PR DESCRIPTION
## Summary
- build CI artifacts with the updated upload-artifact v4 action

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest tests/test_overlay_draw.py tests/test_image_utils.py` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b17507ff2c832a96b9b8180802efbe