### PR TITLE
Refactor camera streams around new BaseStream

### DIFF
--- a/modules/base_stream.py
+++ b/modules/base_stream.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import threading
+from abc import ABC, abstractmethod
+from collections import deque
+from typing import Deque, Optional, Tuple
+
+import numpy as np
+
+
+class BaseStream(ABC):
+    """Generic threaded frame reader with a small queue."""
+
+    def __init__(
+        self,
+        url: str,
+        width: int | None = None,
+        height: int | None = None,
+        transport: str = "tcp",
+        queue_size: int = 30,
+        start_thread: bool = True,
+    ) -> None:
+        self.url = url
+        self.width = width
+        self.height = height
+        self.transport = transport
+        self.queue: Deque[np.ndarray] = deque(maxlen=queue_size)
+        self._stop = False
+        self._thread: Optional[threading.Thread] = None
+        if start_thread:
+            self.start()
+
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        """Start backend and reader thread."""
+        self._start_backend()
+        self._thread = threading.Thread(target=self._reader_loop, daemon=True)
+        self._thread.start()
+
+    def _reader_loop(self) -> None:
+        while not self._stop:
+            frame = self._read_frame()
+            if frame is None:
+                break
+            self.queue.append(frame)
+
+    def read(self) -> Tuple[bool, Optional[np.ndarray]]:
+        return (True, self.queue.popleft()) if self.queue else (False, None)
+
+    def release(self) -> None:
+        self._stop = True
+        self._release_backend()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=1)
+
+    # ------------------------------------------------------------------
+    @abstractmethod
+    def _start_backend(self) -> None:
+        """Start the underlying capture backend."""
+
+    @abstractmethod
+    def _read_frame(self) -> Optional[np.ndarray]:
+        """Read a single frame from the backend."""
+
+    @abstractmethod
+    def _release_backend(self) -> None:
+        """Clean up backend resources."""

--- a/modules/ffmpeg_stream.py
+++ b/modules/ffmpeg_stream.py
@@ -1,15 +1,25 @@
+from __future__ import annotations
+
 import subprocess
-import threading
-from collections import deque
+from typing import Optional
 
 import ffmpeg
 import numpy as np
 
+from .base_stream import BaseStream
 
-class FFmpegCameraStream:
+
+class FFmpegCameraStream(BaseStream):
     def __init__(
-        self, url, width=None, height=None, start_thread=True, downscale=1, **kwargs
-    ):
+        self,
+        url: str,
+        width: int | None = None,
+        height: int | None = None,
+        transport: str = "tcp",
+        start_thread: bool = True,
+        downscale: int = 1,
+        **kwargs,
+    ) -> None:
         self.url = url
         self.width = width
         self.height = height
@@ -24,21 +34,26 @@ class FFmpegCameraStream:
         if downscale and downscale != 1:
             self.width //= downscale
             self.height //= downscale
-
         self.frame_size = self.width * self.height * 3
-        self.queue = deque(maxlen=30)
-        self._stop = False
-        self.proc = None
-        self.t = None
+        self.proc: Optional[subprocess.Popen[bytes]] = None
+        super().__init__(
+            url=url,
+            width=self.width,
+            height=self.height,
+            transport=transport,
+            queue_size=30,
+            start_thread=start_thread,
+        )
 
-        if start_thread:
-            self._start_process()
+    # ------------------------------------------------------------------
+    def _start_backend(self) -> None:
+        self._start_process()
 
-    def _start_process(self):
+    def _start_process(self) -> None:
         cmd = [
             "ffmpeg",
             "-rtsp_transport",
-            "tcp",
+            self.transport,
             "-i",
             self.url,
             "-f",
@@ -49,39 +64,31 @@ class FFmpegCameraStream:
             f"scale={self.width}:{self.height}",
             "pipe:1",
         ]
-
         self.proc = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
         )
+        self._buf = b""
 
-        def _reader():
-            buf = b""
-            while not self._stop:
-                if self.proc.stdout is None:
-                    break
-                chunk = self.proc.stdout.read(self.frame_size - len(buf))
-                if not chunk:
-                    break
-                buf += chunk
-                if len(buf) == self.frame_size:
-                    frame = np.frombuffer(buf, dtype=np.uint8).reshape(
-                        self.height, self.width, 3
-                    )
-                    self.queue.append(frame)
-                    buf = b""
+    def _read_frame(self) -> Optional[np.ndarray]:
+        if not self.proc or self.proc.stdout is None:
+            return None
+        while len(self._buf) < self.frame_size and not self._stop:
+            chunk = self.proc.stdout.read(self.frame_size - len(self._buf))
+            if not chunk:
+                return None
+            self._buf += chunk
+        if len(self._buf) != self.frame_size:
+            return None
+        frame = np.frombuffer(self._buf, dtype=np.uint8).reshape(
+            self.height, self.width, 3
+        )
+        self._buf = b""
+        return frame
 
-        self.t = threading.Thread(target=_reader, daemon=True)
-        self.t.start()
-
-    def read(self):
-        return (True, self.queue.popleft()) if self.queue else (False, None)
-
-    def release(self):
-        self._stop = True
+    def _release_backend(self) -> None:
         if self.proc:
             try:
                 self.proc.terminate()
             except Exception:
                 pass
-        if self.t and self.t.is_alive():
-            self.t.join(timeout=1)
+            self.proc = None

--- a/modules/gstreamer_stream.py
+++ b/modules/gstreamer_stream.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from typing import Optional
+
+from .base_stream import BaseStream
+
 Gst = None
 
 
@@ -29,24 +33,34 @@ def _build_pipeline(
     return " ! ".join(parts)
 
 
-class GstCameraStream:
+class GstCameraStream(BaseStream):
     def __init__(
         self,
         url: str,
-        width: int = 640,
-        height: int = 480,
+        width: int | None = None,
+        height: int | None = None,
         transport: str = "tcp",
         extra_pipeline: str | None = None,
-        buffer_seconds: int = 0,
         start_thread: bool = True,
         **kwargs,
     ) -> None:
-        self.url = url
+        width = width or 640
+        height = height or 480
         self.pipeline = _build_pipeline(url, width, height, transport, extra_pipeline)
         self.last_status = ""
         self.last_pipeline = ""
-        if start_thread:
-            self._init_stream()
+        super().__init__(
+            url=url,
+            width=width,
+            height=height,
+            transport=transport,
+            queue_size=1,
+            start_thread=start_thread,
+        )
+
+    # ------------------------------------------------------------------
+    def _start_backend(self) -> None:
+        self._init_stream()
 
     def _init_stream(self) -> None:
         self.last_pipeline = self.pipeline
@@ -59,5 +73,8 @@ class GstCameraStream:
             self.last_status = "error"
             self.last_pipeline = self.pipeline
 
-    def release(self) -> None:
+    def _read_frame(self) -> Optional[object]:
+        return None
+
+    def _release_backend(self) -> None:
         pass

--- a/modules/opencv_stream.py
+++ b/modules/opencv_stream.py
@@ -1,22 +1,51 @@
+from __future__ import annotations
+
 import platform
+from typing import Optional
 
 import cv2
+import numpy as np
+
+from .base_stream import BaseStream
 
 
-class BaseCameraStream:
-    def __init__(self, src):
-        self.src = src
-        self.buffer_size = 1
+class OpenCVCameraStream(BaseStream):
+    def __init__(
+        self,
+        url: str | int,
+        width: int | None = None,
+        height: int | None = None,
+        transport: str = "tcp",
+        start_thread: bool = True,
+        **kwargs,
+    ) -> None:
+        self.cap: Optional[cv2.VideoCapture] = None
+        super().__init__(
+            url=str(url),
+            width=width,
+            height=height,
+            transport=transport,
+            queue_size=1,
+            start_thread=start_thread,
+        )
 
-
-class OpenCVCameraStream(BaseCameraStream):
-    def __init__(self, src, *args, **kwargs):
-        super().__init__(src)
-        self.cap = None
-
-    def _init_stream(self):
-        src = int(self.src) if str(self.src).isdigit() else self.src
+    # ------------------------------------------------------------------
+    def _start_backend(self) -> None:
+        src = int(self.url) if str(self.url).isdigit() else self.url
         if platform.system() == "Windows":
             self.cap = cv2.VideoCapture(src, cv2.CAP_DSHOW)
         else:
             self.cap = cv2.VideoCapture(src)
+
+    def _read_frame(self) -> Optional[np.ndarray]:
+        if not self.cap:
+            return None
+        ret, frame = self.cap.read()
+        if not ret:
+            return None
+        return frame
+
+    def _release_backend(self) -> None:
+        if self.cap:
+            self.cap.release()
+            self.cap = None

--- a/tests/test_stream_subclasses.py
+++ b/tests/test_stream_subclasses.py
@@ -1,0 +1,46 @@
+"""Minimal tests for stream subclasses using mocked backends."""
+
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault("cv2", type("cv2", (), {}))
+
+from modules.ffmpeg_stream import FFmpegCameraStream  # noqa: E402
+from modules.gstreamer_stream import GstCameraStream  # noqa: E402
+from modules.opencv_stream import OpenCVCameraStream  # noqa: E402
+
+
+def _check_stream(monkeypatch, cls):
+    frame = np.zeros((1, 1, 3), dtype=np.uint8)
+
+    monkeypatch.setattr(cls, "_start_backend", lambda self: None)
+
+    def fake_read(self):
+        self._stop = True
+        return frame
+
+    monkeypatch.setattr(cls, "_read_frame", fake_read)
+    stream = cls("demo", width=1, height=1)
+    time.sleep(0.05)
+    ok, out = stream.read()
+    assert ok
+    assert out.shape == (1, 1, 3)
+    stream.release()
+
+
+def test_ffmpeg_stream(monkeypatch):
+    _check_stream(monkeypatch, FFmpegCameraStream)
+
+
+def test_gst_stream(monkeypatch):
+    _check_stream(monkeypatch, GstCameraStream)
+
+
+def test_opencv_stream(monkeypatch):
+    _check_stream(monkeypatch, OpenCVCameraStream)


### PR DESCRIPTION
## Summary
- add generic `BaseStream` with queue and thread management
- refactor FFmpeg, GStreamer and OpenCV streams to inherit `BaseStream`
- add tests validating mocked frame reads across stream subclasses

## Testing
- `pre-commit run --files modules/base_stream.py modules/ffmpeg_stream.py modules/gstreamer_stream.py modules/opencv_stream.py tests/test_stream_subclasses.py`
- `pytest tests/test_stream_subclasses.py tests/test_gstreamer_pipeline.py::test_build_pipeline_helper tests/test_ffmpeg_stream.py::test_probe_updates_frame_size -q`

------
https://chatgpt.com/codex/tasks/task_e_68b175c77288832a95d5a83d48bc5b53