### PR TITLE
Refactor camera factory to accept explicit config and support async probing

### DIFF
--- a/core/camera_manager.py
+++ b/core/camera_manager.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 from app.core.utils import mtime
 from core.retry_state import RetryState
-from modules.camera_factory import StreamUnavailable, open_capture
+from modules.camera_factory import StreamUnavailable, async_open_capture
 
 # Types for injected functions
 StartFn = Callable[
@@ -230,8 +230,8 @@ class CameraManager:
         cam = self._find_cam(cam_id)
         url = cam.get("url", "") if cam else ""
         try:
-            cap, _ = await asyncio.to_thread(
-                open_capture, url, cam_id, cam.get("type") if cam else None
+            cap, _ = await async_open_capture(
+                self.cfg, url, cam_id, cam.get("type") if cam else None
             )
             try:
                 res = await asyncio.to_thread(cap.read, timeout)

--- a/modules/tracker/stream.py
+++ b/modules/tracker/stream.py
@@ -76,6 +76,7 @@ class CaptureWorker:
                     use_gpu = getattr(dev, "type", "") == "cuda"
 
                 cap, t.rtsp_transport = open_capture(
+                    t.cfg,
                     t.src,
                     t.cam_id,
                     t.src_type,

--- a/tests/test_camera_factory.py
+++ b/tests/test_camera_factory.py
@@ -1,6 +1,7 @@
 import modules.camera_factory as cf
 from config import config as shared_config
 from modules.capture import FrameSourceError, IFrameSource
+import pytest
 
 
 class Dummy(IFrameSource):
@@ -21,29 +22,34 @@ class Dummy(IFrameSource):
         pass
 
 
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
 def test_rtsp_backend_selection(monkeypatch):
     monkeypatch.setattr(cf, "RtspFfmpegSource", Dummy)
     monkeypatch.setattr(cf, "RtspGstSource", Dummy)
     shared_config["camera"] = {"mode": "rtsp", "uri": "rtsp://x"}
     shared_config["use_gstreamer"] = False
-    cap, _ = cf.open_capture(1, capture_buffer=2)
+    cap, _ = cf.open_capture(shared_config, 1, capture_buffer=2)
     assert isinstance(cap, Dummy) and cap.opened
     shared_config["use_gstreamer"] = True
-    cap, _ = cf.open_capture(1)
+    cap, _ = cf.open_capture(shared_config, 1)
     assert isinstance(cap, Dummy) and cap.opened
 
 
 def test_local_backend(monkeypatch):
     monkeypatch.setattr(cf, "LocalCvSource", Dummy)
     shared_config["camera"] = {"mode": "local", "uri": 0}
-    cap, _ = cf.open_capture(1)
+    cap, _ = cf.open_capture(shared_config, 1)
     assert isinstance(cap, Dummy) and cap.opened
 
 
 def test_http_backend(monkeypatch):
     monkeypatch.setattr(cf, "HttpMjpegSource", Dummy)
     shared_config["camera"] = {"mode": "http", "uri": "http://x"}
-    cap, _ = cf.open_capture(1, capture_buffer=3, backend_priority=["http"])
+    cap, _ = cf.open_capture(shared_config, 1, capture_buffer=3, backend_priority=["http"])
     assert isinstance(cap, Dummy) and cap.opened
 
 
@@ -56,7 +62,7 @@ def test_gstreamer_fallback_unsup_codec(monkeypatch):
     monkeypatch.setattr(cf, "RtspFfmpegSource", Dummy)
     shared_config["camera"] = {"mode": "rtsp", "uri": "rtsp://x"}
     shared_config["use_gstreamer"] = True
-    cap, _ = cf.open_capture(1)
+    cap, _ = cf.open_capture(shared_config, 1)
     assert isinstance(cap, Dummy) and cap.opened
 
 
@@ -83,6 +89,19 @@ def test_udp_retry_on_no_video(monkeypatch):
 
     monkeypatch.setattr(cf, "RtspFfmpegSource", FailingDummy)
     shared_config["camera"] = {"mode": "rtsp", "uri": "rtsp://x", "tcp": True}
-    cap, transport = cf.open_capture(1)
+    cap, transport = cf.open_capture(shared_config, 1)
     assert isinstance(cap, FailingDummy) and cap.opened
     assert transport == "udp"
+
+
+@pytest.mark.anyio
+async def test_async_open_capture(monkeypatch):
+    monkeypatch.setattr(cf, "RtspFfmpegSource", Dummy)
+    shared_config["camera"] = {"mode": "rtsp", "uri": "rtsp://x"}
+
+    async def fake_probe(url):
+        return url, "udp", 0, 0, 0.0
+
+    monkeypatch.setattr(cf, "async_probe_rtsp", fake_probe)
+    cap, _ = await cf.async_open_capture(shared_config, 1)
+    assert isinstance(cap, Dummy) and cap.opened

--- a/tests/test_person_tracker_workers.py
+++ b/tests/test_person_tracker_workers.py
@@ -66,9 +66,11 @@ def make_tracker(monkeypatch, frames, once=True):
         output_frame=None,
         preview_scale=1.0,
         _purge_counted=lambda: None,
+        first_frame_ok=False,
+        frame_callback=None,
     )
 
-    def oc(src, cam_id, src_type, resolution, *a, **k):
+    def oc(cfg, src, cam_id, src_type, resolution, *a, **k):
         assert resolution == "640x480"
         return DummyCap(tracker, frames), "tcp"
 
@@ -298,6 +300,7 @@ def test_capture_worker_device_update(monkeypatch):
             return False, None
 
     def oc(
+        cfg,
         src,
         cam_id,
         src_type,
@@ -397,7 +400,7 @@ def test_apply_debug_pipeline_resolution(monkeypatch):
 
     resolutions: list[str] = []
 
-    def oc(src, cam_id, src_type, resolution, *a, **k):
+    def oc(cfg, src, cam_id, src_type, resolution, *a, **k):
         resolutions.append(resolution)
         class Cap:
             def __init__(self):


### PR DESCRIPTION
## Summary
- pass configuration explicitly into `open_capture`
- add async RTSP probing and `async_open_capture`
- adapt capture workers and camera manager to new API
- test sync/async capture paths with mocked sources

## Testing
- `pytest tests/test_camera_factory.py tests/test_person_tracker_workers.py tests/test_camera_manager_helpers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b175d4c0f8832ab00c2046a760cec6