### PR TITLE
Fix MJPEG preview streaming and add health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,18 @@ raw frames without server-side overlays.
 
 `GET /api/cameras/{id}/mjpeg?overlay=1[&thickness=2][&labels=true]` –
 Server-rendered overlay using latest tracker detections.
-JPEG quality can be tuned via the `VMS26_JPEG_QUALITY` environment variable (default: 80).
+
+Environment knobs influencing the preview stream:
+
+- `FRAME_JPEG_QUALITY` – JPEG quality for streamed frames (default `80`).
+- `TARGET_FPS` – throttle outgoing MJPEG rate (default `15`).
+- `NO_FRAME_TIMEOUT_MS` – trigger a capture restart if no frame is received
+  within this window (default `2000`).
+- `HEARTBEAT_INTERVAL_MS` – interval for keep-alive JPEGs during stalls
+  (default `1500`).
+- `RECONNECT_BACKOFF_MS_MIN` / `RECONNECT_BACKOFF_MS_MAX` – bounds for
+  exponential reconnect backoff.
+- `VMS26_RTSP_TCP=1` forces TCP transport for RTSP sources.
 
 Fields accepted by the camera creation endpoint:
 

--- a/docs/camera_preview.md
+++ b/docs/camera_preview.md
@@ -16,6 +16,20 @@ origins.
 
 Streams are transient and stop when the client disconnects.
 
+## Environment variables
+
+The preview subsystem honours several environment variables:
+
+- `FRAME_JPEG_QUALITY` (default `80`) – quality for encoded preview frames.
+- `TARGET_FPS` (default `15`) – maximum rate at which frames are sent.
+- `NO_FRAME_TIMEOUT_MS` (default `2000`) – if no frame is decoded within this
+  window the capture source is restarted.
+- `HEARTBEAT_INTERVAL_MS` (default `1500`) – interval for tiny keep‑alive JPEGs
+  to prevent browser timeouts when the stream stalls.
+- `RECONNECT_BACKOFF_MS_MIN`/`RECONNECT_BACKOFF_MS_MAX` – bounds for exponential
+  backoff when reconnecting to a dropped stream.
+- `VMS26_RTSP_TCP` – set to `1` to force TCP transport for RTSP sources.
+
 ## Example
 
 ```bash

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -23,6 +23,6 @@ cap, _ = open_capture(url, cam_id)
 ## Reconnection
 
 Capture sources now retry automatically using an exponential backoff starting
-at 0.5s and capped by the `VMS26_RECONNECT_MAXSLEEP` environment variable
-(default 8s). To force TCP transport for all RTSP streams, set
-`VMS26_RTSP_TCP=1`.
+at 0.5s (configurable via `RECONNECT_BACKOFF_MS_MIN`) and capped by
+`RECONNECT_BACKOFF_MS_MAX` (both in milliseconds). All RTSP commands default to
+TCP transport; set `VMS26_RTSP_TCP=1` to enforce TCP if a source requests UDP.

--- a/scripts/sanity_rtsp_to_jpeg.sh
+++ b/scripts/sanity_rtsp_to_jpeg.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Quick sanity check: grab a single frame from an RTSP stream using ffmpeg.
+# Usage: ./scripts/sanity_rtsp_to_jpeg.sh rtsp://camera/stream [outfile]
+set -e
+URL="$1"
+OUT="${2:-frame.jpg}"
+ffmpeg -nostdin -hide_banner -loglevel error \
+  -rtsp_transport tcp -stimeout 20000000 -rw_timeout 2000000 \
+  -fflags nobuffer -flags low_delay -probesize 1000000 -analyzeduration 0 \
+  -max_delay 500000 -reorder_queue_size 0 -avioflags direct -an \
+  -i "$URL" -frames:v 1 -f image2 "$OUT"
+echo "Saved $OUT"

--- a/tests/test_camera_mjpeg.py
+++ b/tests/test_camera_mjpeg.py
@@ -1,21 +1,13 @@
 import asyncio
-import io
-import subprocess
+import asyncio
 import sys
 import types
+import time
+import numpy as np
 
 sys.modules.setdefault("cv2", types.SimpleNamespace())
 from routers import cameras
-from modules.email_utils import sign_token
-
-
-class FakeProc:
-    def __init__(self, data: bytes):
-        self.stdout = io.BytesIO(data)
-        self.killed = False
-
-    def kill(self):
-        self.killed = True
+from modules.capture.base import FrameSourceError
 
 
 def setup_function():
@@ -26,20 +18,47 @@ def test_mjpeg_stream(monkeypatch):
     cameras.cams = [{"id": 1, "url": "rtsp://example/stream"}]
     monkeypatch.setattr(cameras, "require_roles", lambda *a, **k: None)
 
-    proc = FakeProc(b"\xff\xd8test\xff\xd9")
-    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: proc)
+    class FakeCap:
+        def __init__(self):
+            self.frames = [np.zeros((1, 1, 3), dtype=np.uint8), np.ones((1, 1, 3), dtype=np.uint8)]
+            self.idx = 0
+            self.last_frame_ts = 0.0
+            self.restarts = 0
+
+        def read(self, timeout=None):
+            if self.idx >= len(self.frames):
+                raise FrameSourceError("READ_TIMEOUT")
+            frame = self.frames[self.idx]
+            self.idx += 1
+            self.last_frame_ts = time.time()
+            return frame
+
+    fake_cap = FakeCap()
+
+    async def fake_get_cap(cam):
+        return fake_cap
+
+    monkeypatch.setattr(cameras, "_get_preview_cap", fake_get_cap)
+
+    def fake_imencode(ext, frame, params):
+        return True, np.frombuffer(b"\xff\xd8test\xff\xd9", dtype=np.uint8)
+
+    monkeypatch.setattr(cameras.cv2, "imencode", fake_imencode, raising=False)
+    monkeypatch.setattr(cameras.cv2, "IMWRITE_JPEG_QUALITY", 1, raising=False)
+    monkeypatch.setattr(cameras, "require_roles", lambda *a, **k: None)
 
     async def _run():
-        tok = sign_token("1", cameras.cfg.get("secret_key", "secret"))
-        resp = await cameras.camera_mjpeg(1, token=tok)
+        resp = await cameras.camera_mjpeg(1)
         assert resp.status_code == 200
         assert (
-            resp.headers["content-type"] == "multipart/x-mixed-replace; boundary=frame"
+            resp.headers["content-type"]
+            == "multipart/x-mixed-replace; boundary=frame"
         )
         gen = resp.body_iterator
         first = await gen.__anext__()
+        second = await gen.__anext__()
         assert b"\xff\xd8" in first
+        assert b"\xff\xd8" in second
         await gen.aclose()
-        assert proc.killed
 
     asyncio.run(_run())

--- a/utils/ffmpeg.py
+++ b/utils/ffmpeg.py
@@ -66,20 +66,37 @@ def build_snapshot_cmd(
     url: str, transport: str, downscale: int | None = None
 ) -> list[str]:
     """Return ffmpeg command for capturing a single JPEG frame."""
-    cmd = [
-        "ffmpeg",
-        "-nostdin",
-        "-hide_banner",
-        "-loglevel",
-        "error",
-        "-nostats",
-        "-rtsp_transport",
-        transport,
-    ]
-    flags = _build_timeout_flags()
-    cmd += flags
-    cmd += ["-i", url, "-an"]
-    cmd += ["-flags", "low_delay", "-fflags", "nobuffer"]
+    cmd = ["ffmpeg", "-nostdin", "-hide_banner", "-loglevel", "error", "-nostats"]
+    if url.startswith("rtsp://"):
+        stimeout = os.getenv("RTSP_STIMEOUT_USEC", "20000000")
+        rw_timeout = os.getenv("RTSP_RW_TIMEOUT_USEC", "2000000")
+        cmd += [
+            "-rtsp_transport",
+            transport,
+            "-stimeout",
+            stimeout,
+            "-rw_timeout",
+            rw_timeout,
+            "-fflags",
+            "nobuffer",
+            "-flags",
+            "low_delay",
+            "-probesize",
+            "1000000",
+            "-analyzeduration",
+            "0",
+            "-max_delay",
+            "500000",
+            "-reorder_queue_size",
+            "0",
+            "-avioflags",
+            "direct",
+            "-an",
+            "-i",
+            url,
+        ]
+    else:
+        cmd += ["-i", url, "-an", "-flags", "low_delay", "-fflags", "nobuffer"]
     if downscale and downscale > 1:
         vf = f"scale=trunc(iw/{downscale}/2)*2:trunc(ih/{downscale}/2)*2"
         cmd += ["-vf", vf]


### PR DESCRIPTION
## Summary
- force RTSP TCP and low-latency flags for ffmpeg and gstreamer capture
- stream MJPEG frames with heartbeat & auto-reconnect, plus camera health endpoint
- document new streaming env vars and add sanity RTSP-to-JPEG script

## Testing
- `pytest tests/test_camera_mjpeg.py::test_mjpeg_stream -q`
- `pytest -q` *(fails: Only a single TORCH_LIBRARY can be used to register the namespace triton...)*


------
https://chatgpt.com/codex/tasks/task_e_68b18b889024832a95eeb92f372878f2