### PR TITLE
ci: install dev dependencies for pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,12 @@ jobs:
           path: jest-results.json
       - name: Install dependencies
         run: pip install -r requirements.txt
+      - name: Install dev dependencies
+        run: pip install -r requirements-dev.txt
       - name: Lint
-        run: pre-commit run --all-files
+        run: |
+          pre-commit install
+          pre-commit run --all-files
       - name: Unit tests
         run: |
           pytest -m "not integration and not gpu and not slow" \


### PR DESCRIPTION
## Summary
- install requirements-dev.txt in CI before linting
- install pre-commit hooks and run pre-commit

## Testing
- `pre-commit run --all-files` *(fails: trailing-whitespace modified many files)*
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q` *(fails: RuntimeError, AttributeError, KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b181b8adc8832ab6ec84e8ef6c7a99