### PR TITLE
feat: allow startup without redis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "fastapi-csrf-protect",
     "ffmpeg-python",
     "keyring",
+    "fakeredis",
 ]
 
 [tool.black]


### PR DESCRIPTION
## Summary
- fall back to `fakeredis` when Redis is unavailable
- include `fakeredis` in project dependencies

## Testing
- `LOG_LEVEL=ERROR DISABLE_FILE_LOGGING=1 pytest tests/test_license.py -q`
- `LOG_LEVEL=ERROR DISABLE_FILE_LOGGING=1 python app.py >/tmp/run.log 2>&1 & sleep 2 && cat /tmp/run.log`


------
https://chatgpt.com/codex/tasks/task_e_68b198a3fe54832a9c28bffc03f9ebbd