### PR TITLE
chore: simplify unit test invocation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,7 @@ jobs:
           pre-commit install
           pre-commit run --all-files
       - name: Unit tests
-        run: |
-          pytest -m "not integration and not gpu and not slow" \
-            --junitxml=unit-tests.xml \
-            --cov=. --cov-report=xml
+        run: pytest -m "not integration and not gpu and not slow" --junitxml=unit-tests.xml --cov=. --cov-report=xml
       - name: Upload JUnit results
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- run unit tests with a single pytest invocation in CI workflow

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -m "not integration and not gpu and not slow" -q` *(fails: RuntimeError: There is no current event loop in thread 'MainThread')*

------
https://chatgpt.com/codex/tasks/task_e_68b1c107f0dc832a867ed2524bcacb35