### PR TITLE
Add lock and conditional rw_timeout handling in RTSP FFmpeg source

### DIFF
--- a/tests/test_rtsp_ffmpeg_source.py
+++ b/tests/test_rtsp_ffmpeg_source.py
@@ -35,3 +35,35 @@ def test_stderr_capture_and_close(monkeypatch, caplog):
     assert any("line1" in r.message for r in caplog.records)
     src.close()
     assert dummy.stdout.closed and dummy.stderr.closed
+
+
+def test_startup_without_rw_timeout(monkeypatch, caplog):
+    class DummyProc:
+        def __init__(self):
+            self.stdout = io.BytesIO()
+            self.stderr = io.BytesIO()
+
+        def terminate(self):
+            pass
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(cmd, capture_output=False, text=False):
+        class R:
+            stdout = ""
+
+        return R()
+
+    def fake_popen(cmd, stdout=None, stderr=None, bufsize=None):
+        captured["cmd"] = cmd
+        return DummyProc()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    with caplog.at_level(logging.WARNING):
+        src = RtspFfmpegSource("rtsp://demo")
+        src.open()
+    assert "cmd" in captured and "-rw_timeout" not in captured["cmd"]
+    assert any("rw_timeout" in r.message for r in caplog.records)
+    src.close()


### PR DESCRIPTION
## Summary
- guard FFmpeg process start/stop with a lock to prevent races
- probe for `-rw_timeout` support and warn when falling back
- test RTSP source startup when `-rw_timeout` is unavailable

## Testing
- `pytest tests/test_rtsp_ffmpeg_source.py::test_stderr_capture_and_close tests/test_rtsp_ffmpeg_source.py::test_startup_without_rw_timeout -q`
- `pre-commit run --files modules/capture/rtsp_ffmpeg.py tests/test_rtsp_ffmpeg_source.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d60c16e8832abf0ddc5f4ca75d1e