### PR TITLE
Skip Redis xadd on empty payload

### DIFF
--- a/tests/test_redis_bus.py
+++ b/tests/test_redis_bus.py
@@ -1,0 +1,25 @@
+"""Tests for app.core.redis_bus helpers."""
+
+from app.core import redis_bus
+
+
+class DummyRedis:
+    def __init__(self):
+        self.called = False
+
+    def xadd(self, *args, **kwargs):
+        self.called = True
+
+
+def test_xadd_event_skips_empty_payload(monkeypatch):
+    dummy = DummyRedis()
+    monkeypatch.setattr(redis_bus, "get_redis", lambda: dummy)
+    redis_bus.xadd_event()
+    assert dummy.called is False
+
+
+def test_xadd_event_publishes_non_empty(monkeypatch):
+    dummy = DummyRedis()
+    monkeypatch.setattr(redis_bus, "get_redis", lambda: dummy)
+    redis_bus.xadd_event(data={"foo": "bar"})
+    assert dummy.called is True


### PR DESCRIPTION
## Summary
- avoid sending Redis stream event when payload is empty
- add regression tests for empty and non-empty xadd cases

## Testing
- `pytest tests/test_redis_bus.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1de23cbb8832a8fa334e32dc8f150