### PR TITLE
feat: sanitize rtsp logs and map stream errors

### DIFF
--- a/modules/capture/http_mjpeg.py
+++ b/modules/capture/http_mjpeg.py
@@ -103,9 +103,9 @@ class HttpMjpegSource(IFrameSource):
 
     def close(self) -> None:
         self._stop.set()
-        if self._thread:
+        if self._thread and self._thread.is_alive():
             self._thread.join(timeout=1)
-            self._thread = None
+        self._thread = None
         if self._resp:
             self._resp.close()
             self._resp = None

--- a/routers/cameras.py
+++ b/routers/cameras.py
@@ -6,7 +6,6 @@ import asyncio
 import base64
 import json
 import os
-import re
 import secrets
 import shlex
 import subprocess
@@ -53,7 +52,8 @@ from utils.ffmpeg_snapshot import capture_snapshot
 from utils.jpeg import encode_jpeg
 from utils.logx import log_throttled
 from utils.overlay import draw_boxes_np
-from utils.url import get_stream_type
+from utils.url import get_stream_type, mask_credentials
+from utils.api_errors import stream_error_message
 
 # utility for resolving stream dimensions
 from utils.video import async_get_stream_resolution
@@ -61,7 +61,6 @@ from utils.video import async_get_stream_resolution
 # ruff: noqa
 
 
-_CRED_RE = re.compile(r"(?<=://)([^:@\s]+):([^@/\s]+)@")
 
 TARGET_FPS = getenv_num("VMS26_TARGET_FPS", 15, int)
 FRAME_JPEG_QUALITY = getenv_num("FRAME_JPEG_QUALITY", 80, int)
@@ -70,13 +69,6 @@ HEARTBEAT_INTERVAL_MS = getenv_num("HEARTBEAT_INTERVAL_MS", 1500, int)
 HEARTBEAT_JPEG = base64.b64decode(
     b"/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD5/ooooA//2Q=="
 )
-
-
-def mask_credentials(text: str) -> str:
-    """Redact credentials in ``text`` for safe logging."""
-    return _CRED_RE.sub("***:***@", text)
-
-
 def require_admin(request: Request):
     """Ensure the current user has the ``admin`` role."""
     return require_roles(request, ["admin"])
@@ -710,22 +702,14 @@ async def add_camera(request: Request, manager: CameraManager = Depends(get_came
 
     ok, status, err, hint = await _probe_url()
     if not ok:
+        msg = stream_error_message(status) or err or "unable to read"
         if status == "auth":
-            return JSONResponse(
-                {"error": err or "Authentication failed", "hint": hint},
-                status_code=401,
-            )
+            return JSONResponse({"error": msg, "hint": hint}, status_code=401)
         if status == "timeout":
-            return JSONResponse(
-                {"error": err or "Connection timed out", "hint": hint},
-                status_code=504,
-            )
+            return JSONResponse({"error": msg, "hint": hint}, status_code=504)
         if status == "dns":
-            return JSONResponse(
-                {"error": err or "DNS lookup failed", "hint": hint},
-                status_code=502,
-            )
-        return JSONResponse({"error": err or "unable to read", "hint": hint}, status_code=500)
+            return JSONResponse({"error": msg, "hint": hint}, status_code=502)
+        return JSONResponse({"error": msg, "hint": hint}, status_code=500)
 
     async with cams_lock:
         if lic:
@@ -1690,7 +1674,7 @@ async def test_camera(request: Request):
     if not result:
         tail_lines = mask_credentials(stderr or "").splitlines()[-50:]
         stderr_tail = "\n".join(tail_lines)
-        payload = {}
+        msg = stream_error_message(status) or err
         code = 400
         suggestion = "Check stream URL or camera accessibility"
 
@@ -1698,16 +1682,17 @@ async def test_camera(request: Request):
             code = 401
             suggestion = "Verify camera credentials"
         elif status == "timeout":
-            payload["error"] = err or "Connection timed out"
+            msg = msg or "Connection timed out"
             suggestion = "Check network connectivity or increase timeout"
         elif status == "dns":
-            payload["error"] = err or "DNS lookup failed"
+            msg = msg or "DNS lookup failed"
             suggestion = "Verify hostname or DNS settings"
         elif status == "network":
-            payload["error"] = err or "Network error"
+            msg = msg or "Network error"
             suggestion = "Check network connectivity or try different transport"
         else:
-            payload["error"] = err or "unable to read"
+            msg = msg or "unable to read"
+        payload = {"error": msg}
         if cmd:
             payload["ffmpeg_cmd"] = mask_credentials(cmd)
         if stderr_tail:

--- a/utils/api_errors.py
+++ b/utils/api_errors.py
@@ -7,6 +7,21 @@ from typing import Any, Mapping
 from fastapi.responses import JSONResponse
 
 
+STREAM_ERROR_MESSAGES: dict[str, str] = {
+    "auth": "auth failed",
+    "codec": "codec unsupported; set camera to H.264 or enable hevc",
+    "url": "invalid URL/path",
+    "transport": "transport failure; try switching TCP/UDP",
+    "timeout": "timeout – camera unreachable",
+}
+
+
+def stream_error_message(code: str) -> str | None:
+    """Return human-readable message for capture error *code*."""
+
+    return STREAM_ERROR_MESSAGES.get(code)
+
+
 def error_response(
     code: str,
     message: str,

--- a/utils/logx.py
+++ b/utils/logx.py
@@ -15,7 +15,7 @@ from loguru import logger
 from redis.exceptions import RedisError
 
 from .redis import get_sync_client
-from .url import mask_creds
+from .url import mask_credentials
 
 # in-memory state for throttling helpers
 _last_times: Dict[str, float] = {}
@@ -73,7 +73,7 @@ def _log(level: str, event: str, **fields: Any) -> None:
 
     for key in ("url", "cmd", "pipeline", "pipeline_info"):
         if key in fields:
-            fields[key] = mask_creds(str(fields[key]))
+            fields[key] = mask_credentials(str(fields[key]))
     _validate(event, fields)
     payload: Dict[str, Any] = {
         "ts": time.time(),

--- a/utils/url.py
+++ b/utils/url.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from urllib.parse import quote, unquote, urlsplit, urlunsplit
 
 
@@ -63,20 +64,19 @@ def get_stream_type(url: str) -> str:
     return "local"
 
 
+_CRED_RE = re.compile(r"(?<=://)([^:@\s]+):([^@/\s]+)@")
+
+
+def mask_credentials(text: str) -> str:
+    """Redact credentials in *text* for safe logging."""
+
+    return _CRED_RE.sub("***:***@", text)
+
+
 def mask_creds(url: str) -> str:
     """Return ``url`` with password replaced by ``***`` if present."""
 
-    if "://" not in url or "@" not in url:
-        return url
-    parts = urlsplit(url)
-    if not parts.username:
-        return url
-    host = parts.hostname or ""
-    if parts.port:
-        host += f":{parts.port}"
-    userinfo = f"{parts.username}:***"
-    netloc = f"{userinfo}@{host}" if host else userinfo
-    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+    return mask_credentials(url)
 
 
 def with_rtsp_transport(url: str, transport: str) -> str:


### PR DESCRIPTION
## Summary
- centralize credential masking for RTSP URLs and apply in logging
- map stream error codes to user-friendly messages
- guard capture threads against unstarted joins

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'Path' from 'routers.visitor' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dc051fe0832aaedd469f66f8ad7f