### PR TITLE
refactor: remove face identifiers from visitor & camera schemas

### DIFF
--- a/routers/cameras.py
+++ b/routers/cameras.py
@@ -401,7 +401,6 @@ async def create_camera_api(camera: dict):
         f"[create_camera_api] saving camera {cam_obj.name} url={sanitized} transport={cam_obj.transport}"
     )
     cam_dict = cam_obj.model_dump()
-    cam_dict["face_recognition"] = cam_dict.pop("face_recog", False)
     cam_dict["site_id"] = cam_dict.get("site_id") or cfg.get("site_id", 1)
     if cam_dict.get("face_recognition") and not cam_dict.get("line"):
         return JSONResponse({"error": "Virtual line required"}, status_code=400)
@@ -609,7 +608,7 @@ async def add_camera(request: Request, manager: CameraManager = Depends(get_came
     src_type = data.get("type", "http")
     ppe = bool(data.get("ppe"))
     visitor = bool(data.get("visitor_mgmt"))
-    face_rec = bool(data.get("face_recognition") or data.get("face_recog"))
+    face_rec = bool(data.get("face_recognition"))
     features = lic.get("features", {})
     counting = data.get("counting", True)
     enabled = bool(data.get("enabled", True))
@@ -941,9 +940,9 @@ async def toggle_vms(cam_id: int, request: Request):
     raise HTTPException(status_code=404, detail="Not found")
 
 
-@router.post("/cameras/{cam_id}/face_recog")
+@router.post("/cameras/{cam_id}/face_recognition")
 @require_feature("face_recognition")
-async def toggle_face_recog(cam_id: int, request: Request):
+async def toggle_face_recognition(cam_id: int, request: Request):
     async with cams_lock:
         for cam in cams:
             if cam["id"] == cam_id:
@@ -988,8 +987,8 @@ async def update_camera(
                     if "visitor_mgmt" in data
                     else cam.get("visitor_mgmt", False)
                 )
-                if "face_recognition" in data or "face_recog" in data:
-                    face_rec = bool(data.get("face_recognition") or data.get("face_recog"))
+                if "face_recognition" in data:
+                    face_rec = bool(data.get("face_recognition"))
                 else:
                     face_rec = cam.get("face_recognition", False)
                 line = data.get("line")
@@ -1006,7 +1005,7 @@ async def update_camera(
                     cam["ppe"] = bool(ppe)
                 if "visitor_mgmt" in data:
                     cam["visitor_mgmt"] = bool(visitor)
-                if "face_recognition" in data or "face_recog" in data:
+                if "face_recognition" in data:
                     cam["face_recognition"] = bool(face_rec)
                     cam["enable_face_counting"] = bool(face_rec)
                 if "enabled" in data:
@@ -1028,7 +1027,6 @@ async def update_camera(
                         "ppe",
                         "visitor_mgmt",
                         "face_recognition",
-                        "face_recog",
                         "tasks",
                     ]
                 ):

--- a/schemas/camera.py
+++ b/schemas/camera.py
@@ -70,7 +70,7 @@ class CameraBase(BaseModel):
     resolution: Optional[Resolution | str] = None
     ppe: Optional[bool] = None
     vms: Optional[bool] = None
-    face_recog: Optional[bool] = None
+    face_recognition: Optional[bool] = None
     inout_count: Optional[bool] = None
     reverse: Optional[bool] = None
     show: Optional[bool] = None
@@ -148,7 +148,7 @@ class CameraCreate(CameraBase):
     resolution: Resolution | str = Resolution.original
     ppe: bool = False
     vms: bool = False
-    face_recog: bool = False
+    face_recognition: bool = False
     inout_count: bool = False
     reverse: bool = False
     show: bool = False

--- a/schemas/visitor.py
+++ b/schemas/visitor.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel
 class VisitorRegisterForm(BaseModel):
     """Form data for the visitor register endpoint."""
 
-    face_id: str
     name: str
     phone: str = ""
     host: str = ""
@@ -19,7 +18,6 @@ class VisitorRegisterForm(BaseModel):
     @classmethod
     def as_form(
         cls,
-        face_id: str = Form(...),
         name: str = Form(...),
         phone: str = Form(""),
         host: str = Form(""),
@@ -27,7 +25,6 @@ class VisitorRegisterForm(BaseModel):
         visitor_type: str = Form(""),
     ) -> "VisitorRegisterForm":
         return cls(
-            face_id=face_id,
             name=name,
             phone=phone,
             host=host,


### PR DESCRIPTION
## Summary
- allow visitor registration without face identifiers
- simplify camera schema to use `face_recognition` flag only

## Testing
- `pytest` *(fails: module 'modules.opencv_stream' has no attribute '...')*

------
https://chatgpt.com/codex/tasks/task_e_68b1dd3a4680832ab881f7c29673d09f