### PR TITLE
Enforce 25-minute timeout for CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   lint-and-unit:
+    timeout-minutes: 25
     runs-on: ubuntu-22.04
     services:
       redis:
@@ -65,6 +66,7 @@ jobs:
 
   integration:
     needs: lint-and-unit
+    timeout-minutes: 25
     runs-on: ubuntu-22.04
     services:
       redis:


### PR DESCRIPTION
## Summary
- enforce 25-minute timeout on lint-and-unit job
- enforce 25-minute timeout on integration job

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -m "not integration and not gpu and not slow" -q` *(fails: AttributeError, TypeError, AssertionError, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f268f1e4832a99fc2a071bdc98be