### PR TITLE
style: fix pre-commit formatting

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -158,7 +158,7 @@
                       <div class="feed-container" data-token="{{ cam.token }}">
                         <img src="/api/cameras/{{ cam.id }}/mjpeg" class="card-img-top feed-img" alt="feed" data-cam="{{cam.id}}">
                       </div>
-                      
+
                     </div>
                 </div>
             {% endfor %}

--- a/utils/api_errors.py
+++ b/utils/api_errors.py
@@ -6,7 +6,6 @@ from typing import Any, Mapping
 
 from fastapi.responses import JSONResponse
 
-
 STREAM_ERROR_MESSAGES: dict[str, str] = {
     "auth": "auth failed",
     "codec": "codec unsupported; set camera to H.264 or enable hevc",


### PR DESCRIPTION
## Summary
- format imports in `utils/api_errors`
- remove trailing whitespace in dashboard template

## Testing
- `pre-commit run --all-files`
- `pytest` *(fails: 98 failed, 193 passed, 57 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f41e27c0832aa7f21b981f57ccca