### PR TITLE
Sanitize FFmpeg stderr and limit restart retries

### DIFF
--- a/docs/capture_error_codes.md
+++ b/docs/capture_error_codes.md
@@ -1,0 +1,14 @@
+# Capture error codes
+
+The capture modules raise `FrameSourceError` with a short code indicating the
+failure reason. Operators can use these codes to diagnose camera issues.
+
+## CONNECT_FAILED
+Raised when FFmpeg cannot reconnect after multiple attempts. The source stops
+and surfaces the last few lines of stderr with credentials removed. Verify
+network reachability and authentication details.
+
+## INVALID_STREAM
+Emitted when FFmpeg reports `Invalid data found when processing input`. This
+usually points to bad credentials or an unsupported stream format. Confirm the
+URL, credentials, and that the camera outputs a compatible codec.

--- a/tests/test_rtsp_ffmpeg_probe.py
+++ b/tests/test_rtsp_ffmpeg_probe.py
@@ -8,7 +8,7 @@ from modules.capture.rtsp_ffmpeg import RtspFfmpegSource
 def test_probe_retries_on_unspecified_size(monkeypatch, caplog):
     calls = []
 
-    def fake_probe(uri, probesize=None, analyzeduration=None):
+    def fake_probe(uri, probesize=None, analyzeduration=None, **kwargs):
         calls.append((probesize, analyzeduration))
         return {"streams": [{"codec_type": "video"}]}
 


### PR DESCRIPTION
## Summary
- mask FFmpeg stderr to hide credentials and detect invalid streams
- stop after repeated restart failures and raise CONNECT_FAILED
- document capture error codes for operators

## Testing
- `pytest tests/test_rtsp_ffmpeg_source.py tests/test_rtsp_ffmpeg_probe.py`

------
https://chatgpt.com/codex/tasks/task_e_68b200d208f4832a83bc8af36db44f46