### PR TITLE
chore: remove vms references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-![CI](https://github.com/ncomputers/vms26/actions/workflows/ci.yml/badge.svg)
-
 # Crowd Management System v81
 
 Version 81 separates the person counting and PPE detection logic into two
@@ -138,7 +136,7 @@ Environment knobs influencing the preview stream:
   (default `1500`).
 - `RECONNECT_BACKOFF_MS_MIN` / `RECONNECT_BACKOFF_MS_MAX` – bounds for
   exponential reconnect backoff.
-- `VMS26_RTSP_TCP=1` forces TCP transport for RTSP sources.
+- `RTSP_TCP=1` forces TCP transport for RTSP sources.
 
 Fields accepted by the camera creation endpoint:
 
@@ -362,7 +360,7 @@ The first camera uses the default pipeline, while the second overrides the trans
 
 Logging is configured via [`logging_config.py`](logging_config.py) using Loguru with JSON output and rotation. Adjust verbosity by setting the `LOG_LEVEL` environment variable (e.g., `LOG_LEVEL=DEBUG`) or by adding a `log_level` entry in `config.json`.
 
-Set `VMS21_COUNTING_PURE=1` to enable the new counting-only pipeline which emits entry/exit events to an in-memory list. The variable is unset by default, preserving the legacy counting behaviour.
+Set `COUNTING_PURE=1` to enable the new counting-only pipeline which emits entry/exit events to an in-memory list. The variable is unset by default, preserving the legacy counting behaviour.
 
 ## Licensing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,9 +45,9 @@ ffmpeg -loglevel error -rtsp_transport tcp -fflags nobuffer -flags low_delay \
 options, and `ffmpeg_flags` appends them. The global `frame_skip` parameter
 drops frames before analysis to reduce load. Capture runs on a background
 thread reading into a preallocated buffer and placing complete frames into a
-small deque whose length is controlled by ``VMS26_QUEUE_MAX`` (default ``2``),
+small deque whose length is controlled by ``QUEUE_MAX`` (default ``2``),
 discarding the oldest frame when full. The processing stage paces work to
-``VMS26_TARGET_FPS`` to avoid backlog growth. Consecutive short reads
+``TARGET_FPS`` to avoid backlog growth. Consecutive short reads
 trigger FFmpeg restarts with exponential backoff. Unexpected EOFs or broken
 pipes cause the reader to restart FFmpeg with an exponential backoff capped at
 10 s, and the total restart count is exposed via the `/debug` endpoint.
@@ -85,7 +85,7 @@ pipes cause the reader to restart FFmpeg with an exponential backoff capped at
 
 A watchdog thread performs periodic housekeeping every 60 s. It prunes
 registered caches beyond 10 000 entries (keeping the newest items) and, when
-``VMS26_CUDA_EMPTY_EVERY=60`` and a CUDA device is present, calls
+``CUDA_EMPTY_EVERY=60`` and a CUDA device is present, calls
 ``torch.cuda.empty_cache()``. Each run logs a throttled ``[perf] housekeeping``
 message including prune counts.
 

--- a/docs/camera_preview.md
+++ b/docs/camera_preview.md
@@ -28,7 +28,7 @@ The preview subsystem honours several environment variables:
   to prevent browser timeouts when the stream stalls.
 - `RECONNECT_BACKOFF_MS_MIN`/`RECONNECT_BACKOFF_MS_MAX` – bounds for exponential
   backoff when reconnecting to a dropped stream.
-- `VMS26_RTSP_TCP` – set to `1` to force TCP transport for RTSP sources.
+- `RTSP_TCP` – set to `1` to force TCP transport for RTSP sources.
 
 ## Example
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -63,7 +63,7 @@ These environment variables affect tests and local development:
 |----------|-------------|
 | `CONFIG_PATH` | Path to the configuration file. Defaults to `config.json`. |
 | `WORKERS` | Override the number of worker threads used by the server. |
-| `VMS26_QUEUE_MAX` | Maximum size of the internal processing queue. |
-| `VMS26_TARGET_FPS` | Target frame processing rate for the pipeline. |
+| `QUEUE_MAX` | Maximum size of the internal processing queue. |
+| `TARGET_FPS` | Target frame processing rate for the pipeline. |
 | `TZ` | Time zone used in tests for date/time handling. |
 | `ALLOW_UNAUTHENTICATED_STREAM` | If set, disables stream authentication in development. |

--- a/docs/models.md
+++ b/docs/models.md
@@ -2,5 +2,5 @@
 
 Detection models are loaded through the [vision registry](../app/vision/registry.py).
 
-* Configure model paths with environment variables `VMS21_YOLO_PERSON` and `VMS21_YOLO_PPE` (default `yolov8s.pt` and `ppe.pt`).
+* Configure model paths with environment variables `YOLO_PERSON` and `YOLO_PPE` (default `yolov8s.pt` and `ppe.pt`).
 * Models typically use the YOLOv8 architecture for person and PPE detection.

--- a/docs/modules/modules_pipeline.md
+++ b/docs/modules/modules_pipeline.md
@@ -5,10 +5,10 @@
 Provides a lightweight demo pipeline comprising a capture loop and a process
 loop. Frames are generated, encoded to JPEG and exposed via
 `get_frame_bytes()` for MJPEG streaming. The capture loop writes frames to a
-bounded ``collections.deque`` controlled by the ``VMS26_QUEUE_MAX`` environment
+bounded ``collections.deque`` controlled by the ``QUEUE_MAX`` environment
 variable (default ``2``). When the deque is full the oldest frame is dropped
 before appending the new one. The process loop pulls frames from the deque,
-sleeping briefly when empty and pacing work to the ``VMS26_TARGET_FPS``
+sleeping briefly when empty and pacing work to the ``TARGET_FPS``
 setting.
 
 ## Key Classes

--- a/docs/modules/routers_cameras.md
+++ b/docs/modules/routers_cameras.md
@@ -10,7 +10,7 @@ to auto-probe common stream paths and logs the selected URL.
 
 ### Environment Variables
 
-- `VMS21_PIPELINE` - When set to `1`, MJPEG frames are streamed from a
+- `PIPELINE` - When set to `1`, MJPEG frames are streamed from a
   lightweight in-process pipeline instead of spawning FFmpeg.
 
 ## Key Classes

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -18,5 +18,5 @@ Redis acts as the central message bus and datastore.
 * The `CFG_VERSION` key increments whenever configuration is updated. Use
   `watch_config` to refresh application settings when this version changes.
 * The ``app.core.redis_bus`` module provides helpers for publishing events to
-  the ``vms21:events`` stream via ``xadd_event`` and for updating
+  the ``events`` stream via ``xadd_event`` and for updating
   ``cam:<id>:state`` hashes through ``set_cam_state`` with an expiry.

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -25,4 +25,4 @@ cap, _ = open_capture(url, cam_id)
 Capture sources now retry automatically using an exponential backoff starting
 at 0.5s (configurable via `RECONNECT_BACKOFF_MS_MIN`) and capped by
 `RECONNECT_BACKOFF_MS_MAX` (both in milliseconds). All RTSP commands default to
-TCP transport; set `VMS26_RTSP_TCP=1` to enforce TCP if a source requests UDP.
+TCP transport; set `RTSP_TCP=1` to enforce TCP if a source requests UDP.

--- a/static/manifest.webmanifest
+++ b/static/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "VMS21",
-  "short_name": "VMS21",
+  "name": "Crowd Management System",
+  "short_name": "CMS",
   "start_url": "/",
   "display": "standalone",
   "scope": "/",

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -45,7 +45,7 @@ workbox.routing.registerRoute(
 
 self.addEventListener('push', event => {
   const data = event.data ? event.data.json() : {};
-  const title = data.title || 'VMS21';
+  const title = data.title || 'Crowd Management System';
   const options = {
     body: data.body || '',
     icon: 'https://via.placeholder.com/192.png',

--- a/static/src-sw.js
+++ b/static/src-sw.js
@@ -45,7 +45,7 @@ workbox.routing.registerRoute(
 
 self.addEventListener('push', event => {
   const data = event.data ? event.data.json() : {};
-  const title = data.title || 'VMS21';
+  const title = data.title || 'Crowd Management System';
   const options = {
     body: data.body || '',
     icon: 'https://via.placeholder.com/192.png',


### PR DESCRIPTION
## Summary
- drop VMS branding from service workers and manifest
- strip VMS-prefixed environment variables from docs and README

## Testing
- `make precommit`
- `make test` *(fails: TypeError cannot unpack non-iterable NoneType object; 71 failed, 142 passed, 2 deselected, 48 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5467f0074832a81e3c12cf956f48a