### PR TITLE
Add stream frame bus and tests

### DIFF
--- a/modules/stream/frame_bus.py
+++ b/modules/stream/frame_bus.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Lightweight in-memory frame bus.
+
+This module provides helper functions for passing frames between a camera
+producer and multiple consumers. Each registered consumer receives frames
+published for a camera via an independent :class:`collections.deque`.
+"""
+
+from collections import deque
+from typing import Any, Deque, Dict, Tuple
+
+# Mapping of (camera_id, consumer_id) -> deque holding (frame, ts_ms) tuples.
+_buffers: Dict[Tuple[str, str], Deque[tuple[Any, int]]] = {}
+
+
+def register(camera_id: str, consumer_id: str, maxlen: int = 10) -> Deque[tuple[Any, int]]:
+    """Register a consumer for a given camera and return its frame deque.
+
+    If the consumer is already registered, the existing deque is returned.
+    """
+
+    key = (camera_id, consumer_id)
+    queue = _buffers.get(key)
+    if queue is None or queue.maxlen != maxlen:
+        queue = deque(maxlen=maxlen)
+        _buffers[key] = queue
+    return queue
+
+
+def unregister(camera_id: str, consumer_id: str) -> None:
+    """Remove a previously registered consumer."""
+
+    _buffers.pop((camera_id, consumer_id), None)
+
+
+def publish(camera_id: str, frame: Any, ts_ms: int) -> None:
+    """Publish a frame to all consumers registered for ``camera_id``.
+
+    Frames are appended without blocking. When a consumer's deque is full,
+    the oldest frame is discarded automatically by :class:`collections.deque`.
+    """
+
+    for (cam, _), queue in list(_buffers.items()):
+        if cam == camera_id:
+            queue.append((frame, ts_ms))

--- a/tests/test_stream_frame_bus.py
+++ b/tests/test_stream_frame_bus.py
@@ -1,0 +1,45 @@
+"""Tests for modules.stream.frame_bus."""
+
+import numpy as np
+
+from modules.stream import frame_bus
+
+
+def setup_function() -> None:
+    frame_bus._buffers.clear()
+
+
+def test_register_and_publish() -> None:
+    q = frame_bus.register("cam1", "cons1", maxlen=2)
+    frame = np.zeros((1, 1), dtype=np.uint8)
+    frame_bus.publish("cam1", frame, 123)
+    assert len(q) == 1
+    out_frame, ts = q[0]
+    assert ts == 123
+    np.testing.assert_array_equal(out_frame, frame)
+
+
+def test_publish_to_multiple_consumers() -> None:
+    q1 = frame_bus.register("cam1", "cons1")
+    q2 = frame_bus.register("cam1", "cons2")
+    frame = np.zeros((1, 1), dtype=np.uint8)
+    frame_bus.publish("cam1", frame, 1)
+    assert len(q1) == 1
+    assert len(q2) == 1
+
+
+def test_unregister_stops_delivery() -> None:
+    q = frame_bus.register("cam1", "cons1")
+    frame_bus.unregister("cam1", "cons1")
+    frame_bus.publish("cam1", np.zeros((1, 1), dtype=np.uint8), 1)
+    assert len(q) == 0
+
+
+def test_publish_drops_oldest() -> None:
+    q = frame_bus.register("cam1", "cons1", maxlen=2)
+    frame_bus.publish("cam1", np.array([[1]], dtype=np.uint8), 1)
+    frame_bus.publish("cam1", np.array([[2]], dtype=np.uint8), 2)
+    frame_bus.publish("cam1", np.array([[3]], dtype=np.uint8), 3)
+    assert len(q) == 2
+    frames = [f[0, 0] for f, _ in q]
+    assert frames == [2, 3]


### PR DESCRIPTION
## Summary
- add lightweight frame bus for camera frames with register/unregister/publish helpers
- cover new frame bus with unit tests

## Testing
- `pre-commit run --files modules/stream/frame_bus.py tests/test_stream_frame_bus.py`
- `pytest tests/test_stream_frame_bus.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b57c693748832a927966deacd79afa