### PR TITLE
Add MJPEG preview publisher and tests

### DIFF
--- a/modules/preview/__init__.py
+++ b/modules/preview/__init__.py
@@ -1,0 +1,3 @@
+"""Preview publishing utilities."""
+
+__all__ = ["mjpeg_publisher"]

--- a/modules/preview/mjpeg_publisher.py
+++ b/modules/preview/mjpeg_publisher.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from typing import AsyncIterator, Dict
+
+from modules.frame_bus import FrameBus
+from utils.jpeg import encode_jpeg
+from utils import logx
+
+
+class PreviewPublisher:
+    """Publish MJPEG frames from :class:`FrameBus` instances."""
+
+    def __init__(self, buses: Dict[int, FrameBus] | None = None) -> None:
+        self._buses: Dict[int, FrameBus] = buses or {}
+        self._showing: set[int] = set()
+        self._clients: defaultdict[int, int] = defaultdict(int)
+
+    # ------------------------------------------------------------------
+    def start_show(self, camera_id: int) -> None:
+        """Enable preview streaming for ``camera_id``."""
+        if camera_id not in self._showing:
+            self._showing.add(camera_id)
+            logx.event("PREVIEW_SHOW", camera_id=camera_id)
+
+    def stop_show(self, camera_id: int) -> None:
+        """Disable preview streaming for ``camera_id``."""
+        if camera_id in self._showing:
+            self._showing.remove(camera_id)
+            logx.event("PREVIEW_HIDE", camera_id=camera_id)
+
+    def is_showing(self, camera_id: int) -> bool:
+        """Return ``True`` if preview is enabled for ``camera_id``."""
+        return camera_id in self._showing
+
+    # ------------------------------------------------------------------
+    async def stream(self, camera_id: int) -> AsyncIterator[bytes]:
+        """Yield MJPEG ``--frame`` chunks for ``camera_id``."""
+        bus = self._buses.get(camera_id)
+        if not bus:
+            return
+        self._clients[camera_id] += 1
+        logx.event("PREVIEW_CLIENT_OPEN", camera_id=camera_id)
+        boundary = b"--frame\r\nContent-Type: image/jpeg\r\n\r\n"
+        try:
+            while self.is_showing(camera_id):
+                frame = await asyncio.to_thread(bus.get_latest, 1000)
+                if frame is None:
+                    continue
+                jpeg = encode_jpeg(frame)
+                yield boundary + jpeg + b"\r\n"
+        finally:
+            self._clients[camera_id] -= 1
+            logx.event("PREVIEW_CLIENT_CLOSE", camera_id=camera_id)

--- a/tests/test_mjpeg_publisher.py
+++ b/tests/test_mjpeg_publisher.py
@@ -1,0 +1,60 @@
+import asyncio
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from modules.frame_bus import FrameBus
+from modules.preview.mjpeg_publisher import PreviewPublisher
+
+
+class DummyConnector:
+    def __init__(self) -> None:
+        self.start_count = 0
+        self.stop_count = 0
+
+    def start(self) -> None:
+        self.start_count += 1
+
+    def stop(self) -> None:
+        self.stop_count += 1
+
+
+def test_preview_toggle_no_connector_restart():
+    connector = DummyConnector()
+    connector.start()
+    bus = FrameBus()
+    pub = PreviewPublisher({1: bus})
+    pub.start_show(1)
+    pub.stop_show(1)
+    assert connector.start_count == 1
+    assert connector.stop_count == 0
+
+
+@pytest.mark.asyncio
+async def test_jpeg_encoding_only_with_clients(monkeypatch):
+    bus = FrameBus()
+    pub = PreviewPublisher({1: bus})
+    calls = SimpleNamespace(count=0)
+
+    def fake_encode(frame):  # type: ignore[override]
+        calls.count += 1
+        return b"jpeg"
+
+    monkeypatch.setattr("modules.preview.mjpeg_publisher.encode_jpeg", fake_encode)
+
+    pub.start_show(1)
+    frame = np.zeros((1, 1, 3), dtype=np.uint8)
+    bus.put(frame)
+    assert calls.count == 0
+
+    gen = pub.stream(1)
+    bus.put(frame)
+    chunk = await asyncio.wait_for(gen.__anext__(), 1)
+    assert chunk.startswith(b"--frame")
+    assert calls.count == 1
+    await gen.aclose()
+
+    bus.put(frame)
+    await asyncio.sleep(0.05)
+    assert calls.count == 1


### PR DESCRIPTION
## Summary
- add PreviewPublisher for MJPEG previews that encodes frames from FrameBus on-demand
- log preview start/stop and client connect/disconnect events
- cover preview behaviour with unit tests

## Testing
- `pytest tests/test_mjpeg_publisher.py -q`
- `pytest -q` *(fails: '71 failed, 142 passed, 2 deselected, 47 errors')*


------
https://chatgpt.com/codex/tasks/task_e_68b57e2a42bc832abb66f20601fc8a83