### PR TITLE
feat: toggle preview show-hide for MJPEG streams

### DIFF
--- a/static/js/mjpeg_feed.js
+++ b/static/js/mjpeg_feed.js
@@ -1,18 +1,45 @@
-(function(){
-  function initMjpegFeeds(root=document){
-    root.querySelectorAll('img.feed-img').forEach(img=>{
-      const modal=img.closest('.modal');
-      if(modal){
-        modal.addEventListener('hidden.bs.modal',()=>img.removeAttribute('src'));
+(function () {
+  function initMjpegFeeds(root = document) {
+    const opened = new Set();
+
+    function openFeed(img) {
+      const id = img.dataset.cam;
+      if (!id || opened.has(img)) return;
+      opened.add(img);
+      fetch(`/api/cameras/${id}/show`, { method: "POST" }).catch(() => {});
+      img.src = `/api/cameras/${id}/mjpeg`;
+    }
+
+    function closeFeed(img) {
+      const id = img.dataset.cam;
+      if (!id || !opened.has(img)) return;
+      opened.delete(img);
+      if (img.src) {
+        img.src = "";
+        img.removeAttribute("src");
+      }
+      fetch(`/api/cameras/${id}/hide`, { method: "POST" }).catch(() => {});
+    }
+
+    root.querySelectorAll("img.feed-img").forEach((img) => {
+      const modal = img.closest(".modal");
+      if (modal) {
+        modal.addEventListener("shown.bs.modal", () => openFeed(img));
+        modal.addEventListener("hidden.bs.modal", () => closeFeed(img));
+      } else {
+        openFeed(img);
+        window.addEventListener("beforeunload", () => closeFeed(img), {
+          once: true,
+        });
       }
     });
   }
-  if (typeof module !== 'undefined') {
+  if (typeof module !== "undefined") {
     module.exports = { initMjpegFeeds };
   } else {
     globalThis.initMjpegFeeds = initMjpegFeeds;
   }
-  if (typeof document !== 'undefined' && !globalThis.__TEST__) {
+  if (typeof document !== "undefined" && !globalThis.__TEST__) {
     initMjpegFeeds();
   }
 })();

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -156,7 +156,7 @@
                         {{cam.name}}
                       </div>
                       <div class="feed-container" data-token="{{ cam.token }}">
-                        <img src="/api/cameras/{{ cam.id }}/mjpeg" class="card-img-top feed-img" alt="feed" data-cam="{{cam.id}}">
+                        <img class="card-img-top feed-img" alt="feed" data-cam="{{cam.id}}">
                       </div>
 
                     </div>
@@ -261,7 +261,7 @@
         {% if cameras %}
         {% set cam = cameras[0] %}
         <div class="col-md-2">
-            <img src="/api/cameras/{{ cam.id }}/mjpeg" class="img-fluid feed-img" alt="feed" data-cam="{{ cam.id }}" data-token="{{ cam.token }}">
+            <img class="img-fluid feed-img" alt="feed" data-cam="{{ cam.id }}" data-token="{{ cam.token }}">
         </div>
         {% endif %}
 
@@ -360,12 +360,6 @@ feeds.forEach(img=>{
   img.addEventListener('load',()=>{
     err.style.display='none';
     img.style.display='';
-  });
-});
-document.querySelectorAll('.modal').forEach(m=>{
-  m.addEventListener('hidden.bs.modal',()=>{
-    const img=m.querySelector('img');
-    if(img) img.removeAttribute('src');
   });
 });
 let graphInit=false;

--- a/templates/troubleshooter.html
+++ b/templates/troubleshooter.html
@@ -23,7 +23,7 @@
             {% for cam in cameras %}
             <tr data-id="{{ cam.id }}">
                 <td>{{ cam.name }}</td>
-                <td><img src="/api/cameras/{{ cam.id }}/mjpeg" class="img-fluid"/></td>
+                <td><img class="img-fluid feed-img" data-cam="{{ cam.id }}"/></td>
                 <td><button class="btn btn-sm btn-outline-primary run-btn">Run diagnostics</button></td>
                 <td><ul class="list-unstyled results small mb-0"></ul></td>
             </tr>
@@ -107,5 +107,6 @@ es.onmessage=e=>{
   list.scrollTop=list.scrollHeight;
 };
 </script>
+<script src="{{ url_for('static', path='js/mjpeg_feed.js') }}"></script>
 </body>
 </html>

--- a/tests/mjpeg_feed.test.js
+++ b/tests/mjpeg_feed.test.js
@@ -2,15 +2,22 @@
  * @jest-environment jsdom
  */
 
-test('removes src on modal hidden', () => {
-  document.body.innerHTML = '<div class="modal"><img class="feed-img" src="foo"></div>';
+test('calls show and hide around modal preview', () => {
+  document.body.innerHTML = '<div class="modal"><img class="feed-img" data-cam="1"></div>';
   globalThis.__TEST__ = true;
+  const fetchMock = jest.fn(() => Promise.resolve({}));
+  global.fetch = fetchMock;
   const fs = require('fs');
   const path = require('path');
   const code = fs.readFileSync(path.resolve(__dirname, '../static/js/mjpeg_feed.js'), 'utf8');
   new Function(code)();
   globalThis.initMjpegFeeds(document);
+  const modal = document.querySelector('.modal');
   const img = document.querySelector('img.feed-img');
-  document.querySelector('.modal').dispatchEvent(new Event('hidden.bs.modal'));
+  modal.dispatchEvent(new Event('shown.bs.modal'));
+  expect(fetchMock).toHaveBeenCalledWith('/api/cameras/1/show', { method: 'POST' });
+  expect(img.src).toContain('/api/cameras/1/mjpeg');
+  modal.dispatchEvent(new Event('hidden.bs.modal'));
+  expect(fetchMock).toHaveBeenLastCalledWith('/api/cameras/1/hide', { method: 'POST' });
   expect(img.getAttribute('src')).toBeNull();
 });


### PR DESCRIPTION
## Summary
- start MJPEG streams only after POSTing /api/cameras/{id}/show and stop with /hide
- drop inline src attributes and wire dashboard and troubleshooter templates to new JS
- add tests guarding preview start/stop without connector restarts

## Testing
- `npm test tests/mjpeg_feed.test.js`
- `pytest tests/integration/test_stream_preview_route.py`


------
https://chatgpt.com/codex/tasks/task_e_68b585806a24832a821d545d0afed60a