### PR TITLE
Include preview status in debug stats

### DIFF
--- a/routers/debug.py
+++ b/routers/debug.py
@@ -133,6 +133,16 @@ async def _collect_cam_info(cams, trackers_map, redisfx, secret):
             except Exception:
                 summary = debug
         stats = tr.get_debug_stats() if tr and hasattr(tr, "get_debug_stats") else {}
+        # Merge in RTSP connector stats and preview state.
+        try:
+            from routers import cameras as cam_router
+
+            conn = cam_router.rtsp_connectors.get(cid)
+            if conn:
+                stats.update(conn.stats())
+            stats["preview"] = cam_router.preview_publisher.is_showing(cid)
+        except Exception:  # pragma: no cover - defensive
+            stats["preview"] = False
         if stats.get("last_capture_ts"):
             stats["last_capture_ts"] = datetime.fromtimestamp(stats["last_capture_ts"]).isoformat()
         if stats.get("last_process_ts"):

--- a/tests/test_camera_mjpeg.py
+++ b/tests/test_camera_mjpeg.py
@@ -91,6 +91,8 @@ def test_show_hide_and_stats(monkeypatch):
         assert stats["state"] == "ok"
         await cameras.camera_hide(1)
         assert not cameras.preview_publisher.is_showing(1)
+        stats2 = await cameras.camera_stats(1)
+        assert stats2["preview"] is False
         assert fake_conn.started == 0 and fake_conn.stopped == 0
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- merge RTSP connector stats and preview state into debug camera info
- verify preview flag via camera stats tests
- ensure debug overview includes preview and connector state

## Testing
- `pre-commit run --files routers/debug.py tests/test_camera_mjpeg.py tests/test_debug_camera.py`
- `pytest tests/test_camera_mjpeg.py::test_show_hide_and_stats tests/test_debug_camera.py::test_debug_camera_page -q`


------
https://chatgpt.com/codex/tasks/task_e_68b587414814832ab4e43b476046a007